### PR TITLE
ex-command, stylua and q to close

### DIFF
--- a/lua/kubectl/actions.lua
+++ b/lua/kubectl/actions.lua
@@ -25,6 +25,8 @@ function M.new_buffer(content, filetype, opts)
 
 	if opts.is_float then
 		layout.float_layout(buf, filetype, opts.title or "", opts.syntax or filetype)
+		vim.bo[buf].buflisted = false
+		vim.keymap.set("n", "q", vim.cmd.close, { buffer = buf, silent = true })
 	else
 		api.nvim_set_current_buf(buf)
 		layout.main_layout(buf, filetype, opts.syntax or filetype)

--- a/lua/kubectl/commands.lua
+++ b/lua/kubectl/commands.lua
@@ -1,4 +1,60 @@
-local M = {}
+local M = {
+	top_level_commands = {
+		"annotate",
+		"api-resources",
+		"api-versions",
+		"apply",
+		"attach",
+		"auth",
+		"autoscale",
+		"certificate",
+		"cluster-info",
+		"completion",
+		"config",
+		"cordon",
+		"cp",
+		"create",
+		"debug",
+		"delete",
+		"describe",
+		"diff",
+		"drain",
+		"edit",
+		"events",
+		"exec",
+		"explain",
+		"expose",
+		"get",
+		"help",
+		"kustomize",
+		"label",
+		"logs",
+		"options",
+		"patch",
+		"port-forward",
+		"proxy",
+		"replace",
+		"rollout",
+		"run",
+		"scale",
+		"set",
+		"taint",
+		"top",
+		"uncordon",
+		"version",
+		"wait",
+	},
+}
+
+function M.user_command_completion(_, cmd)
+	local parts = {}
+	for part in string.gmatch(cmd, "%S+") do
+		table.insert(parts, part)
+	end
+	if #parts == 1 then
+		return M.top_level_commands
+	end
+end
 
 -- Function to execute a shell command and return the output as a table of strings
 function M.execute_shell_command(cmd, args)

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -1,4 +1,9 @@
 local pod_view = require("kubectl.pods.views")
+local deployment_view = require("kubectl.deployments.views")
+local events_view = require("kubectl.events.views")
+local nodes_view = require("kubectl.nodes.views")
+local secrets_view = require("kubectl.secrets.views")
+local services_view = require("kubectl.services.views")
 local view = require("kubectl.view")
 local config = require("kubectl.config")
 local commands = require("kubectl.commands")
@@ -22,9 +27,28 @@ function M.setup(options)
 end
 
 vim.api.nvim_create_user_command("Kubectl", function(opts)
-	view.UserCmd(opts.fargs)
+	if opts.fargs[1] == "get" then
+		if vim.tbl_contains({ "pods", "pod", "po" }, opts.fargs[2]) then
+			pod_view.Pods()
+		elseif vim.tbl_contains({ "deployments", "deployment", "deploy" }, opts.fargs[2]) then
+			deployment_view.Deployments()
+		elseif vim.tbl_contains({ "events", "event", "ev" }, opts.fargs[2]) then
+			events_view.Events()
+		elseif vim.tbl_contains({ "nodes", "node", "no" }, opts.fargs[2]) then
+			nodes_view.Nodes()
+		elseif vim.tbl_contains({ "secrets", "secret", "sec" }, opts.fargs[2]) then
+			secrets_view.Secrets()
+		elseif vim.tbl_contains({ "services", "service", "svc" }, opts.fargs[2]) then
+			services_view.Services()
+		else
+			view.UserCmd(opts.fargs)
+		end
+	else
+		view.UserCmd(opts.fargs)
+	end
 end, {
 	nargs = "*",
+	complete = commands.user_command_completion,
 })
 
 return M

--- a/stylelua.toml
+++ b/stylelua.toml
@@ -1,3 +1,0 @@
-indent_type = "Spaces"
-indent_width = 2
-column_width = 120

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Tabs"
+indent_width = 6
+column_width = 120


### PR DESCRIPTION
## Changes

- quit floats with <kbd>q</kbd>
- offer some completion to `:Kubectl` ex-command
- Open the existing views if we try `:Kubectl get {existing_view}`
  I'm not a big fan of the `if..elseif..elseif..else` so if you have a better alternative, please offer.
- fix stylua filename and indentation by Tabs (this is what the repo is using, I'd rather using spaces but it's your choice, just align stylua accordingly)