### PR TITLE
feat: use extmarks instead of match

### DIFF
--- a/ftplugin/k8s_configmaps.lua
+++ b/ftplugin/k8s_configmaps.lua
@@ -9,9 +9,7 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected pod \n")
-    view.Hints(hints)
+    view.Hints({ { key = "<d>", desc = "Describe selected pod" } })
   end,
 })
 

--- a/ftplugin/k8s_deployments.lua
+++ b/ftplugin/k8s_deployments.lua
@@ -12,12 +12,11 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<r>", "Restart selected deployment \n")
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected deployment \n")
-    hints = hints .. tables.generateHintLine("<enter>", "Opens pods view \n")
-
-    view.Hints(hints)
+    view.Hints({
+      { key = "<r>", desc = "Restart selected deployment" },
+      { key = "<d>", desc = "Describe selected deployment" },
+      { key = "<enter>", desc = "Opens pods view" },
+    })
   end,
 })
 

--- a/ftplugin/k8s_events.lua
+++ b/ftplugin/k8s_events.lua
@@ -9,9 +9,7 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<enter>", "Read message \n")
-    view.Hints(hints)
+    view.Hints({ { key = "<enter>", desc = "Read message" } })
   end,
 })
 

--- a/ftplugin/k8s_nodes.lua
+++ b/ftplugin/k8s_nodes.lua
@@ -9,9 +9,7 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected node \n")
-    view.Hints(hints)
+    view.Hints({ { key = "<d>", desc = "Describe selected node" } })
   end,
 })
 

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -96,9 +96,8 @@ api.nvim_buf_set_keymap(0, "n", "<C-k>", "", {
     local namespace, pod_name = tables.getCurrentSelection(unpack(col_indices))
 
     if pod_name and namespace then
-      local delete_pod_query = "delete pod " .. pod_name .. " -n " .. namespace
       print("Deleting pod..")
-      commands.execute_shell_command("kubectl", delete_pod_query)
+      commands.shell_command_async("kubectl", { "delete", "pod", pod_name, "-n", namespace })
       pod_view.Pods()
     else
       api.nvim_err_writeln("Failed to select pod.")

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -21,14 +21,6 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
       { key = "<shift-f>", desc = "Port forward" },
       { key = "<C-k>", desc = "Kill pod" },
     }
-
-
-    -- hints = hints .. tables.generateHintLine("<l>", "Shows logs for all containers in pod \n")
-    -- hints = hints .. tables.generateHintLine("<d>", "Describe selected pod \n")
-    -- hints = hints .. tables.generateHintLine("<t>", "Show resources used \n")
-    -- hints = hints .. tables.generateHintLine("<enter>", "Opens container view \n")
-    -- hints = hints .. tables.generateHintLine("<shift-f>", "Port forward \n")
-    -- hints = hints .. tables.generateHintLine("<C-k>", "Kill pod \n")
     view.Hints(hints)
   end,
 })

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -13,15 +13,14 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = {
+    view.Hints({
       { key = "<l>", desc = "Shows logs for all containers in pod" },
       { key = "<d>", desc = "Describe selected pod" },
       { key = "<t>", desc = "Show resources used" },
       { key = "<enter>", desc = "Opens container view" },
       { key = "<shift-f>", desc = "Port forward" },
       { key = "<C-k>", desc = "Kill pod" },
-    }
-    view.Hints(hints)
+    })
   end,
 })
 

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -13,13 +13,22 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<l>", "Shows logs for all containers in pod \n")
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected pod \n")
-    hints = hints .. tables.generateHintLine("<t>", "Show resources used \n")
-    hints = hints .. tables.generateHintLine("<enter>", "Opens container view \n")
-    hints = hints .. tables.generateHintLine("<shift-f>", "Port forward \n")
-    hints = hints .. tables.generateHintLine("<C-k>", "Kill pod \n")
+    local hints = {
+      { key = "<l>", desc = "Shows logs for all containers in pod" },
+      { key = "<d>", desc = "Describe selected pod" },
+      { key = "<t>", desc = "Show resources used" },
+      { key = "<enter>", desc = "Opens container view" },
+      { key = "<shift-f>", desc = "Port forward" },
+      { key = "<C-k>", desc = "Kill pod" },
+    }
+
+
+    -- hints = hints .. tables.generateHintLine("<l>", "Shows logs for all containers in pod \n")
+    -- hints = hints .. tables.generateHintLine("<d>", "Describe selected pod \n")
+    -- hints = hints .. tables.generateHintLine("<t>", "Show resources used \n")
+    -- hints = hints .. tables.generateHintLine("<enter>", "Opens container view \n")
+    -- hints = hints .. tables.generateHintLine("<shift-f>", "Port forward \n")
+    -- hints = hints .. tables.generateHintLine("<C-k>", "Kill pod \n")
     view.Hints(hints)
   end,
 })

--- a/ftplugin/k8s_root.lua
+++ b/ftplugin/k8s_root.lua
@@ -1,9 +1,9 @@
+local configmaps_view = require("kubectl.views.configmaps")
 local deployment_view = require("kubectl.views.deployments")
 local event_view = require("kubectl.views.events")
 local node_view = require("kubectl.views.nodes")
 local secret_view = require("kubectl.views.secrets")
 local service_view = require("kubectl.views.services")
-local configmaps_view = require("kubectl.views.configmaps")
 local api = vim.api
 
 local function getCurrentSelection()

--- a/ftplugin/k8s_secrets.lua
+++ b/ftplugin/k8s_secrets.lua
@@ -9,9 +9,7 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected secret \n")
-    view.Hints(hints)
+    view.Hints({ { key = "<d>", desc = "Describe selected secret" } })
   end,
 })
 

--- a/ftplugin/k8s_services.lua
+++ b/ftplugin/k8s_services.lua
@@ -9,9 +9,7 @@ api.nvim_buf_set_keymap(0, "n", "g?", "", {
   noremap = true,
   silent = true,
   callback = function()
-    local hints = ""
-    hints = hints .. tables.generateHintLine("<d>", "Describe selected service \n")
-    view.Hints(hints)
+    view.Hints({ { key = "<d>", desc = "Describe selected service" } })
   end,
 })
 

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -120,7 +120,20 @@ function M.floating_buffer(content, filetype, opts)
   hl.set_highlighting(win)
 end
 
-function M.buffer(content, filetype, opts)
+local function apply_extmarks(bufnr, extmarks)
+  local ns_id = api.nvim_create_namespace("highlight_namespace")
+
+  for _, mark in ipairs(extmarks) do
+    local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, mark.row, mark.start_col, {
+      end_line = mark.row,
+      end_col = mark.end_col,
+      hl_group = mark.hl_group,
+      strict = false
+    })
+  end
+end
+
+function M.buffer(content, extmarks, filetype, opts)
   local bufname = opts.title or "kubectl"
   local buf = vim.fn.bufnr(bufname, false)
 
@@ -134,6 +147,9 @@ function M.buffer(content, filetype, opts)
 
   api.nvim_set_current_buf(buf)
   hl.set_highlighting(win)
+  apply_extmarks(buf, extmarks)
+  -- hl.setup()
+  -- hl.set_highlighting()
 end
 
 function M.notification_buffer(content, opts)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -26,8 +26,8 @@ local function apply_marks(bufnr, marks, header)
   api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
 
   vim.schedule(function()
-    if header and header.extmarks then
-      for _, mark in ipairs(header.extmarks) do
+    if header and header.marks then
+      for _, mark in ipairs(header.marks) do
         local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, mark.row, mark.start_col, {
           end_line = mark.row,
           end_col = mark.end_col,
@@ -53,7 +53,7 @@ local function apply_marks(bufnr, marks, header)
   end)
 end
 
-function M.filter_buffer(content, filetype, opts)
+function M.filter_buffer(content, marks, filetype, opts)
   local bufname = "kubectl_filter"
   local buf = vim.fn.bufnr(bufname, false)
 
@@ -67,8 +67,8 @@ function M.filter_buffer(content, filetype, opts)
 
   local win = layout.filter_layout(buf, filetype, opts.title or "")
 
-  api.nvim_buf_set_lines(buf, 0, #opts.hints, false, opts.hints)
-  vim.api.nvim_buf_set_lines(buf, #opts.hints, -1, false, { content .. state.getFilter() })
+  api.nvim_buf_set_lines(buf, 0, #opts.header.data, false, opts.header.data)
+  vim.api.nvim_buf_set_lines(buf, #opts.header.data, -1, false, { content .. state.getFilter() })
 
   vim.fn.prompt_setcallback(buf, function(input)
     if not input then
@@ -83,6 +83,7 @@ function M.filter_buffer(content, filetype, opts)
   vim.cmd("startinsert")
 
   layout.set_buf_options(buf, win, filetype, "")
+  apply_marks(buf, marks, opts.header)
 end
 
 function M.confirmation_buffer(prompt, filetype, onConfirm)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -38,7 +38,10 @@ local function apply_marks(bufnr, marks, header)
     end
     if marks then
       for _, mark in ipairs(marks) do
-        local start_row = #header.data + mark.row
+        local start_row = mark.row
+        if header and header.data then
+          start_row = start_row + #header.data
+        end
         local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, start_row, mark.start_col, {
           end_line = start_row,
           end_col = mark.end_col,

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -22,7 +22,7 @@ local function set_buffer_lines(buf, header, content)
 end
 
 local function apply_marks(bufnr, marks, header)
-  local ns_id = api.nvim_create_namespace("highlight_namespace")
+  local ns_id = api.nvim_create_namespace("__kubectl_namespace")
   api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
 
   vim.schedule(function()

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -122,15 +122,18 @@ end
 
 local function apply_extmarks(bufnr, extmarks)
   local ns_id = api.nvim_create_namespace("highlight_namespace")
+  api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
 
-  for _, mark in ipairs(extmarks) do
-    local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, mark.row, mark.start_col, {
-      end_line = mark.row,
-      end_col = mark.end_col,
-      hl_group = mark.hl_group,
-      strict = false
-    })
-  end
+  vim.schedule(function()
+    for _, mark in ipairs(extmarks) do
+      local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, mark.row, mark.start_col, {
+        end_line = mark.row,
+        end_col = mark.end_col,
+        hl_group = mark.hl_group,
+        strict = false,
+      })
+    end
+  end)
 end
 
 function M.buffer(content, extmarks, filetype, opts)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -105,7 +105,7 @@ function M.confirmation_buffer(prompt, filetype, onConfirm)
       row = (vim.api.nvim_win_get_height(0) - #content + 1) * 0.5,
     },
     relative = "win",
-    header = {}
+    header = {},
   }
 
   set_buffer_lines(buf, opts.header.data, content)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -129,7 +129,7 @@ function M.confirmation_buffer(prompt, filetype, onConfirm)
   layout.set_buf_options(buf, win, filetype, opts.syntax or filetype)
 end
 
-function M.floating_buffer(content, extmarks, filetype, opts)
+function M.floating_buffer(content, marks, filetype, opts)
   local bufname = opts.title or "kubectl_float"
   local buf = vim.fn.bufnr(bufname, false)
 
@@ -143,10 +143,10 @@ function M.floating_buffer(content, extmarks, filetype, opts)
   vim.keymap.set("n", "q", vim.cmd.close, { buffer = buf, silent = true })
 
   layout.set_buf_options(buf, win, filetype, opts.syntax or filetype)
-  apply_marks(buf, extmarks, opts.header)
+  apply_marks(buf, marks, opts.header)
 end
 
-function M.buffer(content, extmarks, filetype, opts)
+function M.buffer(content, marks, filetype, opts)
   local bufname = opts.title or "kubectl"
   local buf = vim.fn.bufnr(bufname, false)
   local win = layout.main_layout()
@@ -158,7 +158,7 @@ function M.buffer(content, extmarks, filetype, opts)
 
   set_buffer_lines(buf, opts.header.data, content)
   api.nvim_set_current_buf(buf)
-  apply_marks(buf, extmarks, opts.header)
+  apply_marks(buf, marks, opts.header)
 end
 
 function M.notification_buffer(content, opts)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -32,7 +32,6 @@ local function apply_marks(bufnr, marks, header)
           end_line = mark.row,
           end_col = mark.end_col,
           hl_group = mark.hl_group,
-          strict = false,
         })
       end
     end
@@ -46,7 +45,6 @@ local function apply_marks(bufnr, marks, header)
           end_line = start_row,
           end_col = mark.end_col,
           hl_group = mark.hl_group,
-          strict = false,
         })
       end
     end

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -105,6 +105,7 @@ function M.confirmation_buffer(prompt, filetype, onConfirm)
       row = (vim.api.nvim_win_get_height(0) - #content + 1) * 0.5,
     },
     relative = "win",
+    header = {}
   }
 
   set_buffer_lines(buf, opts.header.data, content)

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -76,7 +76,9 @@ function M.filter_buffer(content, marks, filetype, opts)
     else
       state.setFilter(input)
     end
-    vim.api.nvim_win_close(win, true)
+
+    vim.bo.modified = false
+    vim.cmd.close()
     vim.api.nvim_input("R")
   end)
 

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -39,9 +39,6 @@ local function apply_marks(bufnr, marks, header)
     if marks then
       for _, mark in ipairs(marks) do
         local start_row = #header.data + mark.row
-        if mark.is_header then
-          start_row = mark.row
-        end
         local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, start_row, mark.start_col, {
           end_line = start_row,
           end_col = mark.end_col,

--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -132,6 +132,7 @@ end
 
 function M.floating_buffer(content, marks, filetype, opts)
   local bufname = opts.title or "kubectl_float"
+  opts.header = opts.header or {}
   local buf = vim.fn.bufnr(bufname, false)
 
   if buf == -1 then
@@ -149,6 +150,7 @@ end
 
 function M.buffer(content, marks, filetype, opts)
   local bufname = opts.title or "kubectl"
+  opts.header = opts.header or {}
   local buf = vim.fn.bufnr(bufname, false)
   local win = layout.main_layout()
 

--- a/lua/kubectl/actions/highlight.lua
+++ b/lua/kubectl/actions/highlight.lua
@@ -15,19 +15,19 @@ vim.api.nvim_set_hl(0, "KubectlGray", { fg = "#666666" }) -- Dark Gray
 
 -- Define M.symbols for tags
 M.symbols = {
-  header = "◆",
-  warning = "⚠",
-  error = "✖",
-  info = "ℹ",
-  debug = "⚑",
-  success = "✓",
-  pending = "☐",
-  deprecated = "☠",
-  experimental = "⚙",
-  gray = "░",
-  note = "✎",
-  clear = "➤",
-  tab = "↹",
+  header = "KubectlHeader",
+  warning = "KubectlWarning",
+  error = "KubectlError",
+  info = "KubectlInfo",
+  debug = "KubectlDebug",
+  success = "KubectlSuccess",
+  pending = "KubectlPending",
+  deprecated = "KubectlDeprecated",
+  experimental = "KubectlExperimental",
+  gray = "KubectlGray",
+  note = "KubectlNote",
+  clear = "KubectlClear",
+  tab = "KubectlTab",
 }
 
 local tag_patterns = {
@@ -51,20 +51,20 @@ local tag_patterns = {
 }
 
 function M.setup(win)
-  win = win or vim.api.nvim_get_current_win()
-  for _, tag in ipairs(tag_patterns) do
-    vim.fn.matchadd(tag.group, tag.pattern, 100, -1, { conceal = "", window = win })
-  end
+  -- win = win or vim.api.nvim_get_current_win()
+  -- for _, tag in ipairs(tag_patterns) do
+  --   vim.fn.matchadd(tag.group, tag.pattern, 100, -1, { conceal = "", window = win })
+  -- end
 end
 
 function M.set_highlighting(win)
-  win = win or vim.api.nvim_get_current_win()
-  for _, symbol in pairs(M.symbols) do
-    vim.cmd("call win_execute(" .. win .. ", 'syntax match Conceal" .. ' "' .. symbol .. '" conceal' .. "')")
-  end
-
-  api.nvim_set_option_value("conceallevel", 3, { scope = "local", win = win })
-  api.nvim_set_option_value("concealcursor", "nc", { scope = "local", win = win })
+  -- win = win or vim.api.nvim_get_current_win()
+  -- for _, symbol in pairs(M.symbols) do
+  --   vim.cmd("call win_execute(" .. win .. ", 'syntax match Conceal" .. ' "' .. symbol .. '" conceal' .. "')")
+  -- end
+  --
+  -- api.nvim_set_option_value("conceallevel", 3, { scope = "local", win = win })
+  -- api.nvim_set_option_value("concealcursor", "nc", { scope = "local", win = win })
 end
 
 return M

--- a/lua/kubectl/actions/highlight.lua
+++ b/lua/kubectl/actions/highlight.lua
@@ -1,18 +1,6 @@
 local M = {}
 local api = vim.api
 
-vim.api.nvim_set_hl(0, "KubectlHeader", { fg = "#569CD6" }) -- Blue
-vim.api.nvim_set_hl(0, "KubectlWarning", { fg = "#D19A66" }) -- Orange
-vim.api.nvim_set_hl(0, "KubectlError", { fg = "#D16969" }) -- Red
-vim.api.nvim_set_hl(0, "KubectlInfo", { fg = "#608B4E" }) -- Green
-vim.api.nvim_set_hl(0, "KubectlDebug", { fg = "#DCDCAA" }) -- Yellow
-vim.api.nvim_set_hl(0, "KubectlSuccess", { fg = "#4EC9B0" }) -- Cyan
-vim.api.nvim_set_hl(0, "KubectlPending", { fg = "#C586C0" }) -- Purple
-vim.api.nvim_set_hl(0, "KubectlDeprecated", { fg = "#D4A5A5" }) -- Pink
-vim.api.nvim_set_hl(0, "KubectlExperimental", { fg = "#CE9178" }) -- Brown
-vim.api.nvim_set_hl(0, "KubectlNote", { fg = "#9CDCFE" }) -- Light Blue
-vim.api.nvim_set_hl(0, "KubectlGray", { fg = "#666666" }) -- Dark Gray
-
 -- Define M.symbols for tags
 M.symbols = {
   header = "KubectlHeader",
@@ -29,42 +17,18 @@ M.symbols = {
   clear = "KubectlClear",
   tab = "KubectlTab",
 }
-
-local tag_patterns = {
-  { pattern = M.symbols.header .. "[^" .. M.symbols.header .. M.symbols.clear .. "]*", group = "KubectlHeader" },
-  { pattern = M.symbols.warning .. "[^" .. M.symbols.warning .. M.symbols.clear .. "]*", group = "KubectlWarning" },
-  { pattern = M.symbols.error .. "[^" .. M.symbols.error .. M.symbols.clear .. "]*", group = "KubectlError" },
-  { pattern = M.symbols.info .. "[^" .. M.symbols.info .. M.symbols.clear .. "]*", group = "KubectlInfo" },
-  { pattern = M.symbols.debug .. "[^" .. M.symbols.debug .. M.symbols.clear .. "]*", group = "KubectlDebug" },
-  { pattern = M.symbols.success .. "[^" .. M.symbols.success .. M.symbols.clear .. "]*", group = "KubectlSuccess" },
-  { pattern = M.symbols.pending .. "[^" .. M.symbols.pending .. M.symbols.clear .. "]*", group = "KubectlPending" },
-  { pattern = M.symbols.gray .. "[^" .. M.symbols.pending .. M.symbols.clear .. "]*", group = "KubectlGray" },
-  {
-    pattern = M.symbols.deprecated .. "[^" .. M.symbols.deprecated .. M.symbols.clear .. "]*",
-    group = "KubectlDeprecated",
-  },
-  {
-    pattern = M.symbols.experimental .. "[^" .. M.symbols.experimental .. M.symbols.clear .. "]*",
-    group = "KubectlExperimental",
-  },
-  { pattern = M.symbols.note .. "[^" .. M.symbols.note .. M.symbols.clear .. "]*", group = "KubectlNote" },
-}
-
-function M.setup(win)
-  -- win = win or vim.api.nvim_get_current_win()
-  -- for _, tag in ipairs(tag_patterns) do
-  --   vim.fn.matchadd(tag.group, tag.pattern, 100, -1, { conceal = "", window = win })
-  -- end
-end
-
-function M.set_highlighting(win)
-  -- win = win or vim.api.nvim_get_current_win()
-  -- for _, symbol in pairs(M.symbols) do
-  --   vim.cmd("call win_execute(" .. win .. ", 'syntax match Conceal" .. ' "' .. symbol .. '" conceal' .. "')")
-  -- end
-  --
-  -- api.nvim_set_option_value("conceallevel", 3, { scope = "local", win = win })
-  -- api.nvim_set_option_value("concealcursor", "nc", { scope = "local", win = win })
+function M.setup()
+  api.nvim_set_hl(0, "KubectlHeader", { fg = "#569CD6" }) -- Blue
+  api.nvim_set_hl(0, "KubectlWarning", { fg = "#D19A66" }) -- Orange
+  api.nvim_set_hl(0, "KubectlError", { fg = "#D16969" }) -- Red
+  api.nvim_set_hl(0, "KubectlInfo", { fg = "#608B4E" }) -- Green
+  api.nvim_set_hl(0, "KubectlDebug", { fg = "#DCDCAA" }) -- Yellow
+  api.nvim_set_hl(0, "KubectlSuccess", { fg = "#4EC9B0" }) -- Cyan
+  api.nvim_set_hl(0, "KubectlPending", { fg = "#C586C0" }) -- Purple
+  api.nvim_set_hl(0, "KubectlDeprecated", { fg = "#D4A5A5" }) -- Pink
+  api.nvim_set_hl(0, "KubectlExperimental", { fg = "#CE9178" }) -- Brown
+  api.nvim_set_hl(0, "KubectlNote", { fg = "#9CDCFE" }) -- Light Blue
+  api.nvim_set_hl(0, "KubectlGray", { fg = "#666666" }) -- Dark Gray
 end
 
 return M

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -14,6 +14,7 @@ function ResourceBuilder:new(resource, args)
   local self = setmetatable({}, ResourceBuilder)
   self.resource = resource
   self.args = args
+  self.header = { data = nil, extmarks = nil }
   return self
 end
 
@@ -121,7 +122,7 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context)
   notifications.Add({
     hl.symbols.gray .. "adding hints " .. "[" .. self.resource .. "]",
   })
-  self.hints = tables.generateHints(hints, include_defaults, include_context)
+  self.header.data, self.header.extmarks = tables.generateHints(hints, include_defaults, include_context)
   return self
 end
 
@@ -138,7 +139,7 @@ function ResourceBuilder:display(filetype, title, cancellationToken)
     hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
-  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, hints = self.hints })
+  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, header = self.header})
 end
 
 function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -139,7 +139,7 @@ function ResourceBuilder:display(filetype, title, cancellationToken)
     hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
-  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, header = self.header})
+  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, header = self.header })
 end
 
 function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)
@@ -149,7 +149,7 @@ function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)
     hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
-  actions.floating_buffer(displayData, filetype, { title = title, syntax = syntax, hints = self.hints })
+  actions.floating_buffer(displayData, self.extmarks, filetype, { title = title, syntax = syntax, header = self.header })
 
   return self
 end

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -122,7 +122,7 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context)
   notifications.Add({
     hl.symbols.gray .. "adding hints " .. "[" .. self.resource .. "]",
   })
-  self.header.data, self.header.extmarks = tables.generateHints(hints, include_defaults, include_context)
+  self.header.data, self.header.extmarks = tables.generateHeader(hints, include_defaults, include_context)
   return self
 end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -14,7 +14,7 @@ function ResourceBuilder:new(resource, args)
   local self = setmetatable({}, ResourceBuilder)
   self.resource = resource
   self.args = args
-  self.header = { data = nil, extmarks = nil }
+  self.header = { data = nil, marks = nil }
   return self
 end
 
@@ -122,7 +122,7 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context)
   notifications.Add({
     hl.symbols.gray .. "adding hints " .. "[" .. self.resource .. "]",
   })
-  self.header.data, self.header.extmarks = tables.generateHeader(hints, include_defaults, include_context)
+  self.header.data, self.header.marks = tables.generateHeader(hints, include_defaults, include_context)
   return self
 end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -113,7 +113,7 @@ function ResourceBuilder:prettyPrint(headersFunc)
   notifications.Add({
     hl.symbols.gray .. "prettify table " .. "[" .. self.resource .. "]",
   })
-  self.prettyData = tables.pretty_print(self.processedData, headersFunc())
+  self.prettyData, self.extmarks = tables.pretty_print(self.processedData, headersFunc())
   return self
 end
 
@@ -138,7 +138,7 @@ function ResourceBuilder:display(filetype, title, cancellationToken)
     hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
-  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), filetype, { title = title, hints = self.hints })
+  actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, hints = self.hints })
 end
 
 function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -24,6 +24,10 @@ function M.generateHeader(headers, include_defaults, include_context)
   local hints = {}
   local extmarks = {}
 
+  local function addExtmark(row, start_col, end_col, hl_group)
+    table.insert(extmarks, { row = row, start_col = start_col, end_col = end_col, hl_group = hl_group })
+  end
+
   if include_defaults then
     local defaults = {
       { key = "<R>", desc = "reload" },
@@ -40,7 +44,7 @@ function M.generateHeader(headers, include_defaults, include_context)
   if config.options.hints then
     local hint_line = "Hint: "
     local length = #hint_line
-    table.insert(extmarks, { row = 0, start_col = 0, end_col = #hint_line, hl_group = hl.symbols.success })
+    addExtmark(0, 0, length, hl.symbols.success)
 
     for index, hintConfig in ipairs(headers) do
       length = #hint_line
@@ -48,7 +52,7 @@ function M.generateHeader(headers, include_defaults, include_context)
       if index < #headers then
         hint_line = hint_line .. " | "
       end
-      table.insert(extmarks, { row = 0, start_col = length, end_col = length + #hintConfig.key, hl_group = hl.symbols.pending })
+      addExtmark(0, length, length + #hintConfig.key, hl.symbols.pending)
     end
 
     table.insert(hints, hint_line .. "\n\n")
@@ -63,30 +67,20 @@ function M.generateHeader(headers, include_defaults, include_context)
         table.insert(hints, line)
       end
       if context.contexts then
-        local desc = "Context:   "
-        local line = desc .. context.contexts[1].context.cluster .. "\n"
+        local desc, context_info = "Context:   ", context.contexts[1].context
+        local line = desc .. context_info.cluster .. "\n"
         table.insert(hints, line)
 
-        table.insert(extmarks, {
-          row = #hints,
-          start_col = #desc,
-          end_col = #line,
-          hl_group = hl.symbols.pending,
-        })
+        addExtmark(#hints, #desc, #line, hl.symbols.pending)
 
-        line = "User:      " .. context.contexts[1].context.user .. "\n"
+        line = "User:      " .. context_info.user .. "\n"
         table.insert(hints, line)
       end
-      local desc = "Namespace: "
-      local line = desc .. state.getNamespace() .. "\n"
+      local desc, namespace = "Namespace: ", state.getNamespace()
+      local line = desc .. namespace .. "\n"
       table.insert(hints, line)
 
-      table.insert(extmarks, {
-        row = #hints,
-        start_col = #desc,
-        end_col = #line,
-        hl_group = hl.symbols.pending,
-      })
+      addExtmark(#hints, #desc, #line, hl.symbols.pending)
     end
   end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -26,7 +26,7 @@ end
 
 function M.generateHeader(headers, include_defaults, include_context)
   local hints = {}
-  local extmarks = {}
+  local marks = {}
 
   if include_defaults then
     local defaults = {
@@ -44,7 +44,7 @@ function M.generateHeader(headers, include_defaults, include_context)
   if config.options.hints then
     local hint_line = "Hint: "
     local length = #hint_line
-    addExtmark(extmarks, 0, 0, length, hl.symbols.success)
+    addExtmark(marks, #hints, 0, length, hl.symbols.success)
 
     for index, hintConfig in ipairs(headers) do
       length = #hint_line
@@ -52,7 +52,7 @@ function M.generateHeader(headers, include_defaults, include_context)
       if index < #headers then
         hint_line = hint_line .. " | "
       end
-      addExtmark(extmarks, 0, length, length + #hintConfig.key, hl.symbols.pending)
+      addExtmark(marks, #hints, length, length + #hintConfig.key, hl.symbols.pending)
     end
 
     table.insert(hints, hint_line .. "\n\n")
@@ -68,19 +68,17 @@ function M.generateHeader(headers, include_defaults, include_context)
       end
       if context.contexts then
         local desc, context_info = "Context:   ", context.contexts[1].context
-        local line = desc .. context_info.cluster .. "\n"
-        table.insert(hints, line)
-
-        addExtmark(extmarks, #hints, #desc, #line, hl.symbols.pending)
+        local line = desc .. context_info.cluster
+        table.insert(hints, line .. "\n")
+        addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
 
         line = "User:      " .. context_info.user .. "\n"
         table.insert(hints, line)
       end
       local desc, namespace = "Namespace: ", state.getNamespace()
-      local line = desc .. namespace .. "\n"
-      table.insert(hints, line)
-
-      addExtmark(extmarks, #hints, #desc, #line, hl.symbols.pending)
+      local line = desc .. namespace
+      table.insert(hints, line .. "\n")
+      addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
     end
   end
 
@@ -90,10 +88,10 @@ function M.generateHeader(headers, include_defaults, include_context)
     table.insert(hints, string.rep("―", vim.api.nvim_win_get_width(win)))
   end
 
-  print("hints:", vim.inspect(hints))
   if #hints > 0 then
-    return vim.split(table.concat(hints, ""), "\n"), extmarks
+    return vim.split(table.concat(hints, ""), "\n"), marks
   end
+  return hints, marks
 end
 
 function M.pretty_print(data, headers)

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -20,7 +20,7 @@ local function calculate_column_widths(rows, columns)
   return widths
 end
 
-function M.generateHeader(hintConfigs, include_defaults, include_context)
+function M.generateHeader(headers, include_defaults, include_context)
   local hints = {}
   local extmarks = {}
 
@@ -32,7 +32,7 @@ function M.generateHeader(hintConfigs, include_defaults, include_context)
       { key = "<g?>", desc = "help" },
     }
     for _, default in ipairs(defaults) do
-      table.insert(hintConfigs, default)
+      table.insert(headers, default)
     end
   end
 
@@ -40,10 +40,11 @@ function M.generateHeader(hintConfigs, include_defaults, include_context)
     local hint_line = "Hint: "
     local length = #hint_line
     table.insert(extmarks, { row = 0, start_col = 0, end_col = #hint_line, hl_group = hl.symbols.success })
-    for index, hintConfig in ipairs(hintConfigs) do
+
+    for index, hintConfig in ipairs(headers) do
       length = #hint_line
       hint_line = hint_line .. hintConfig.key .. " " .. hintConfig.desc
-      if index < #hintConfigs then
+      if index < #headers then
         hint_line = hint_line .. " | "
       end
       table.insert(extmarks, { row = 0, start_col = length, end_col = length + #hintConfig.key, hl_group = hl.symbols.pending })
@@ -53,26 +54,26 @@ function M.generateHeader(hintConfigs, include_defaults, include_context)
   end
 
   if include_context and config.options.context then
-    local hint = ""
+    local context_line = ""
 
     local context = state.getContext()
     if context then
       if context.cluster then
-        hint = hint .. "Cluster:   " .. context.clusters[1].name .. "\n"
+        context_line = context_line .. "Cluster:   " .. context.clusters[1].name .. "\n"
       end
       if context.contexts then
-        hint = hint .. "Context:   " .. context.contexts[1].context.cluster .. "\n"
+        context_line = context_line .. "Context:   " .. context.contexts[1].context.cluster .. "\n"
 
         table.insert(extmarks, {
           row = #hints + 1,
-          start_col = #hint - #context.contexts[1].context.cluster - 1,
-          end_col = #hint,
+          start_col = #context_line - #context.contexts[1].context.cluster - 1,
+          end_col = #context_line,
           hl_group = hl.symbols.pending,
         })
-        hint = hint .. "User:      " .. context.contexts[1].context.user .. "\n"
+        context_line = context_line .. "User:      " .. context.contexts[1].context.user .. "\n"
       end
-      hint = hint .. "Namespace: " .. hl.symbols.pending .. state.getNamespace() .. hl.symbols.clear .. "\n"
-      table.insert(hints, hint)
+      context_line = context_line .. "Namespace: " .. hl.symbols.pending .. state.getNamespace() .. hl.symbols.clear .. "\n"
+      table.insert(hints, context_line)
     end
   end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -19,14 +19,14 @@ local function calculate_column_widths(rows, columns)
 
   return widths
 end
-local function addExtmark(extmarks, row, start_col, end_col, hl_group)
+function M.add_mark(extmarks, row, start_col, end_col, hl_group)
   table.insert(extmarks, { row = row, start_col = start_col, end_col = end_col, hl_group = hl_group })
 end
 
-function M.addHeaderRow(headers, hints, marks)
+local function addHeaderRow(headers, hints, marks)
   local hint_line = "Hint: "
   local length = #hint_line
-  addExtmark(marks, #hints, 0, length, hl.symbols.success)
+  M.add_mark(marks, #hints, 0, length, hl.symbols.success)
 
   for index, hintConfig in ipairs(headers) do
     length = #hint_line
@@ -34,7 +34,7 @@ function M.addHeaderRow(headers, hints, marks)
     if index < #headers then
       hint_line = hint_line .. " | "
     end
-    addExtmark(marks, #hints, length, length + #hintConfig.key, hl.symbols.pending)
+    M.add_mark(marks, #hints, length, length + #hintConfig.key, hl.symbols.pending)
   end
 
   table.insert(hints, hint_line .. "\n")
@@ -48,7 +48,7 @@ local function addContextRows(context, hints, marks)
   if context.contexts then
     local desc, context_info = "Context:   ", context.contexts[1].context
     local line = desc .. context_info.cluster
-    addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
+    M.add_mark(marks, #hints, #desc, #line, hl.symbols.pending)
     table.insert(hints, line .. "\n")
 
     line = "User:      " .. context_info.user .. "\n"
@@ -56,7 +56,7 @@ local function addContextRows(context, hints, marks)
   end
   local desc, namespace = "Namespace: ", state.getNamespace()
   local line = desc .. namespace
-  addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
+  M.add_mark(marks, #hints, #desc, #line, hl.symbols.pending)
   table.insert(hints, line .. "\n")
 end
 
@@ -78,7 +78,7 @@ function M.generateHeader(headers, include_defaults, include_context)
 
   -- Add hints rows
   if config.options.hints then
-    M.addHeaderRow(headers, hints, marks)
+    addHeaderRow(headers, hints, marks)
     table.insert(hints, "\n")
   end
 
@@ -123,7 +123,7 @@ function M.pretty_print(data, headers)
     local value = header .. "  " .. string.rep(" ", column_width - #header + 1)
     table.insert(header_line, value)
 
-    addExtmark(extmarks, 0, #table.concat(header_line, "") - #value, #table.concat(header_line, ""), hl.symbols.header)
+    M.add_mark(extmarks, 0, #table.concat(header_line, "") - #value, #table.concat(header_line, ""), hl.symbols.header)
   end
   table.insert(tbl, table.concat(header_line, ""))
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -90,7 +90,10 @@ function M.generateHeader(headers, include_defaults, include_context)
     table.insert(hints, string.rep("―", vim.api.nvim_win_get_width(win)))
   end
 
-  return vim.split(table.concat(hints, ""), "\n"), extmarks
+  print("hints:", vim.inspect(hints))
+  if #hints > 0 then
+    return vim.split(table.concat(hints, ""), "\n"), extmarks
+  end
 end
 
 function M.pretty_print(data, headers)

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -36,6 +36,7 @@ function M.generateHeader(headers, include_defaults, include_context)
     end
   end
 
+  -- Add hints rows
   if config.options.hints then
     local hint_line = "Hint: "
     local length = #hint_line
@@ -53,30 +54,43 @@ function M.generateHeader(headers, include_defaults, include_context)
     table.insert(hints, hint_line .. "\n\n")
   end
 
+  -- Add context rows
   if include_context and config.options.context then
-    local context_line = ""
-
     local context = state.getContext()
     if context then
-      if context.cluster then
-        context_line = context_line .. "Cluster:   " .. context.clusters[1].name .. "\n"
+      if context.clusters then
+        local line = "Cluster:   " .. context.clusters[1].name .. "\n"
+        table.insert(hints, line)
       end
       if context.contexts then
-        context_line = context_line .. "Context:   " .. context.contexts[1].context.cluster .. "\n"
+        local desc = "Context:   "
+        local line = desc .. context.contexts[1].context.cluster .. "\n"
+        table.insert(hints, line)
 
         table.insert(extmarks, {
-          row = #hints + 1,
-          start_col = #context_line - #context.contexts[1].context.cluster - 1,
-          end_col = #context_line,
+          row = #hints,
+          start_col = #desc,
+          end_col = #line,
           hl_group = hl.symbols.pending,
         })
-        context_line = context_line .. "User:      " .. context.contexts[1].context.user .. "\n"
+
+        line = "User:      " .. context.contexts[1].context.user .. "\n"
+        table.insert(hints, line)
       end
-      context_line = context_line .. "Namespace: " .. hl.symbols.pending .. state.getNamespace() .. hl.symbols.clear .. "\n"
-      table.insert(hints, context_line)
+      local desc = "Namespace: "
+      local line = desc .. state.getNamespace() .. "\n"
+      table.insert(hints, line)
+
+      table.insert(extmarks, {
+        row = #hints,
+        start_col = #desc,
+        end_col = #line,
+        hl_group = hl.symbols.pending,
+      })
     end
   end
 
+  -- Add separator row
   if #hints > 0 then
     local win = vim.api.nvim_get_current_win()
     table.insert(hints, string.rep("―", vim.api.nvim_win_get_width(win)))

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -55,7 +55,8 @@ function M.generateHeader(headers, include_defaults, include_context)
       addExtmark(marks, #hints, length, length + #hintConfig.key, hl.symbols.pending)
     end
 
-    table.insert(hints, hint_line .. "\n\n")
+    table.insert(hints, hint_line .. "\n")
+    table.insert(hints, "\n")
   end
 
   -- Add context rows
@@ -69,16 +70,16 @@ function M.generateHeader(headers, include_defaults, include_context)
       if context.contexts then
         local desc, context_info = "Context:   ", context.contexts[1].context
         local line = desc .. context_info.cluster
-        table.insert(hints, line .. "\n")
         addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
+        table.insert(hints, line .. "\n")
 
         line = "User:      " .. context_info.user .. "\n"
         table.insert(hints, line)
       end
       local desc, namespace = "Namespace: ", state.getNamespace()
       local line = desc .. namespace
-      table.insert(hints, line .. "\n")
       addExtmark(marks, #hints, #desc, #line, hl.symbols.pending)
+      table.insert(hints, line .. "\n")
     end
   end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -20,7 +20,7 @@ local function calculate_column_widths(rows, columns)
   return widths
 end
 
-function M.generateHints(hintConfigs, include_defaults, include_context)
+function M.generateHeader(hintConfigs, include_defaults, include_context)
   local hints = {}
   local extmarks = {}
 

--- a/lua/kubectl/views/containers/definition.lua
+++ b/lua/kubectl/views/containers/definition.lua
@@ -24,21 +24,23 @@ end
 function M.processContainerRow(row)
   local data = {}
 
-  for _, container in pairs(row.spec.containers) do
-    for _, status in ipairs(row.status.containerStatuses) do
-      if status.name == container.name then
-        local result = {
-          name = container.name,
-          image = container.image,
-          ready = status.ready,
-          state = getContainerState(status.state),
-          init = false,
-          restarts = status.restartCount,
-          ports = getPorts(container.ports),
-          age = time.since(row.metadata.creationTimestamp),
-        }
+  if row.spec and row.status and row.status.containerStatuses then
+    for _, container in pairs(row.spec.containers) do
+      for _, status in ipairs(row.status.containerStatuses) do
+        if status.name == container.name then
+          local result = {
+            name = container.name,
+            image = container.image,
+            ready = status.ready,
+            state = getContainerState(status.state),
+            init = false,
+            restarts = status.restartCount,
+            ports = getPorts(container.ports),
+            age = time.since(row.metadata.creationTimestamp),
+          }
 
-        table.insert(data, result)
+          table.insert(data, result)
+        end
       end
     end
   end

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -45,7 +45,7 @@ function M.tailLogs(pod, ns)
 end
 
 function M.exec(pod, ns)
-  actions.floating_buffer({ "" }, {}, "k8s_container_exec", { title = "ssh " .. M.selection, header = {} })
+  actions.floating_buffer({ "" }, {}, "k8s_container_exec", { title = "ssh " .. M.selection })
   commands.execute_terminal("kubectl", { "exec", "-it", pod, "-n", ns, "-c ", M.selection, "--", "/bin/sh" })
 end
 

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -45,7 +45,7 @@ function M.tailLogs(pod, ns)
 end
 
 function M.exec(pod, ns)
-  actions.floating_buffer({ "" }, "k8s_container_exec", { title = "ssh " .. M.selection })
+  actions.floating_buffer({ "" }, {}, "k8s_container_exec", { title = "ssh " .. M.selection, header = {} })
   commands.execute_terminal("kubectl", { "exec", "-it", pod, "-n", ns, "-c ", M.selection, "--", "/bin/sh" })
 end
 

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -4,11 +4,11 @@ local tables = require("kubectl.utils.tables")
 local M = {}
 
 function M.filter()
-  local hints = tables.generateHeader({
+  local header, marks = tables.generateHeader({
     { key = "<enter>", desc = "apply" },
     { key = "<q>", desc = "close" },
   }, false, false)
-  actions.filter_buffer("Filter: ", "k8s_filter", { title = "Filter", hints = hints })
+  actions.filter_buffer("Filter: ", marks, "k8s_filter", { title = "Filter", header = { data = header, marks = marks } })
 end
 
 return M

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -4,7 +4,7 @@ local tables = require("kubectl.utils.tables")
 local M = {}
 
 function M.filter()
-  local hints = tables.generateHints({
+  local hints = tables.generateHeader({
     { key = "<enter>", desc = "apply" },
     { key = "<q>", desc = "close" },
   }, false, false)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -8,30 +8,44 @@ local M = {}
 function M.Hints(headers)
   local marks = {}
   local hints = {}
-  tables.addHeaderRow(headers, hints, marks)
-  print(vim.inspect(headers))
-  print(vim.inspect(hints))
-  -- local hints = {}
-  -- local line = hl.symbols.success
-  --   .. "Buffer mappings: \n"
-  --   .. hl.symbols.clear
-  --   .. hint
-  --   .. "\n"
-  --   .. hl.symbols.success
-  --   .. "Global mappings: \n"
-  --   .. hl.symbols.clear
-  --   .. tables.generateHintLine("<C-f>", "Filter on a phrase\n")
-  --   .. tables.generateHintLine("<C-n>", "Change namespace \n")
-  --   .. tables.generateHintLine("<bs> ", "Go up a level \n")
-  --   .. tables.generateHintLine("<R>  ", "Refresh view \n")
-  --   .. tables.generateHintLine("<1>  ", "Deployments \n")
-  --   .. tables.generateHintLine("<2>  ", "Pods \n")
-  --   .. tables.generateHintLine("<3>  ", "Configmaps \n")
-  --   .. tables.generateHintLine("<4>  ", "Secrets \n")
-  --   .. tables.generateHintLine("<5>  ", "Services \n")
-  --
-  -- table.insert(hints, line)
-  -- actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), "k8s_hints", { title = "Hints" })
+  local globals = {
+    { key = "<C-f>", desc = "Filter on a phrase" },
+    { key = "<C-n>", desc = "Change namespace" },
+    { key = "<bs> ", desc = "Go up a level" },
+    { key = "<R>  ", desc = "Refresh view" },
+    { key = "<1>  ", desc = "Deployments" },
+    { key = "<2>  ", desc = "Pods " },
+    { key = "<3>  ", desc = "Configmaps " },
+    { key = "<4>  ", desc = "Secrets " },
+    { key = "<5>  ", desc = "Services" },
+  }
+
+  local title = "Buffer mappings: "
+  tables.add_mark(marks, #hints, 0, #title, hl.symbols.success)
+  table.insert(hints, title .. "\n")
+  table.insert(hints, "\n")
+
+  local start_row = #hints
+  for index, header in ipairs(headers) do
+    local line = header.key .. " " .. header.desc
+    table.insert(hints, line .. "\n")
+    tables.add_mark(marks, start_row + index - 1, 0, #header.key, hl.symbols.pending)
+  end
+
+  table.insert(hints, "\n")
+  title = "Global mappings: "
+  tables.add_mark(marks, #hints, 0, #title, hl.symbols.success)
+  table.insert(hints, title .. "\n")
+  table.insert(hints, "\n")
+
+  start_row = #hints
+  for index, header in ipairs(globals) do
+    local line = header.key .. " " .. header.desc
+    table.insert(hints, line .. "\n")
+    tables.add_mark(marks, start_row + index - 1, 0, #header.key, hl.symbols.pending)
+  end
+
+  actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), marks, "k8s_hints", { title = "Hints", header = {} })
 end
 
 function M.UserCmd(args)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -45,7 +45,7 @@ function M.Hints(headers)
     tables.add_mark(marks, start_row + index - 1, 0, #header.key, hl.symbols.pending)
   end
 
-  actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), marks, "k8s_hints", { title = "Hints", header = {} })
+  actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), marks, "k8s_hints", { title = "Hints" })
 end
 
 function M.UserCmd(args)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -5,28 +5,33 @@ local tables = require("kubectl.utils.tables")
 
 local M = {}
 
-function M.Hints(hint)
+function M.Hints(headers)
+  local marks = {}
   local hints = {}
-  local line = hl.symbols.success
-    .. "Buffer mappings: \n"
-    .. hl.symbols.clear
-    .. hint
-    .. "\n"
-    .. hl.symbols.success
-    .. "Global mappings: \n"
-    .. hl.symbols.clear
-    .. tables.generateHintLine("<C-f>", "Filter on a phrase\n")
-    .. tables.generateHintLine("<C-n>", "Change namespace \n")
-    .. tables.generateHintLine("<bs> ", "Go up a level \n")
-    .. tables.generateHintLine("<R>  ", "Refresh view \n")
-    .. tables.generateHintLine("<1>  ", "Deployments \n")
-    .. tables.generateHintLine("<2>  ", "Pods \n")
-    .. tables.generateHintLine("<3>  ", "Configmaps \n")
-    .. tables.generateHintLine("<4>  ", "Secrets \n")
-    .. tables.generateHintLine("<5>  ", "Services \n")
-
-  table.insert(hints, line)
-  actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), "k8s_hints", { title = "Hints" })
+  tables.addHeaderRow(headers, hints, marks)
+  print(vim.inspect(headers))
+  print(vim.inspect(hints))
+  -- local hints = {}
+  -- local line = hl.symbols.success
+  --   .. "Buffer mappings: \n"
+  --   .. hl.symbols.clear
+  --   .. hint
+  --   .. "\n"
+  --   .. hl.symbols.success
+  --   .. "Global mappings: \n"
+  --   .. hl.symbols.clear
+  --   .. tables.generateHintLine("<C-f>", "Filter on a phrase\n")
+  --   .. tables.generateHintLine("<C-n>", "Change namespace \n")
+  --   .. tables.generateHintLine("<bs> ", "Go up a level \n")
+  --   .. tables.generateHintLine("<R>  ", "Refresh view \n")
+  --   .. tables.generateHintLine("<1>  ", "Deployments \n")
+  --   .. tables.generateHintLine("<2>  ", "Pods \n")
+  --   .. tables.generateHintLine("<3>  ", "Configmaps \n")
+  --   .. tables.generateHintLine("<4>  ", "Secrets \n")
+  --   .. tables.generateHintLine("<5>  ", "Services \n")
+  --
+  -- table.insert(hints, line)
+  -- actions.floating_buffer(vim.split(table.concat(hints, ""), "\n"), "k8s_hints", { title = "Hints" })
 end
 
 function M.UserCmd(args)

--- a/lua/kubectl/views/root/init.lua
+++ b/lua/kubectl/views/root/init.lua
@@ -12,10 +12,10 @@ function M.Root()
     "Services",
     "Configmaps",
   }
-  local hints = tables.generateHeader({
+  local header, marks = tables.generateHeader({
     { key = "<enter>", desc = "Select" },
   }, true, true)
-  actions.buffer(results, {}, "k8s_root", { title = "Root", hints = hints })
+  actions.buffer(results, {}, "k8s_root", { title = "Root", header = { data = header, marks = marks } })
 end
 
 return M

--- a/lua/kubectl/views/root/init.lua
+++ b/lua/kubectl/views/root/init.lua
@@ -12,7 +12,7 @@ function M.Root()
     "Services",
     "Configmaps",
   }
-  local hints = tables.generateHints({
+  local hints = tables.generateHeader({
     { key = "<enter>", desc = "Select" },
   }, true, true)
   actions.buffer(results, {}, "k8s_root", { title = "Root", hints = hints })

--- a/lua/kubectl/views/root/init.lua
+++ b/lua/kubectl/views/root/init.lua
@@ -10,12 +10,12 @@ function M.Root()
     "Nodes",
     "Secrets",
     "Services",
-    "Configmaps"
+    "Configmaps",
   }
   local hints = tables.generateHints({
     { key = "<enter>", desc = "Select" },
   }, true, true)
-  actions.buffer(results, "k8s_root", { title = "Root", hints = hints })
+  actions.buffer(results, {}, "k8s_root", { title = "Root", hints = hints })
 end
 
 return M


### PR DESCRIPTION
Investigating if this is a good idea for highlighting and maybe for keeping track of rows for acting on them.

+ no need for concealed symbols
+ possibility to add more utility to it in the future (for example virtual text for sorting visualisation)
- slower, we have to iterate through each row to assign the extmarks (testing shows that this is about 2ms for 2k marks)
- not as easy to determine where to highlight, need to calculate row/columns
- seems a bit taxing on neovim (was caused by not clearing the namespace)