### PR TITLE
feat: usemarks to highlight notifications

### DIFF
--- a/lua/kubectl/actions/actions.lua
+++ b/lua/kubectl/actions/actions.lua
@@ -1,3 +1,4 @@
+local hl = require("kubectl.actions.highlight")
 local layout = require("kubectl.actions.layout")
 local state = require("kubectl.state")
 local api = vim.api
@@ -171,6 +172,7 @@ end
 
 function M.notification_buffer(content, opts)
   local bufname = "notification"
+  local marks = {}
   local buf = vim.fn.bufnr(bufname, false)
 
   if opts.close then
@@ -186,16 +188,18 @@ function M.notification_buffer(content, opts)
 
   if opts.append then
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    for _, line in ipairs(lines) do
+    for index, line in ipairs(lines) do
       table.insert(content, #content, line)
     end
   end
 
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
-  local win = layout.notification_layout(buf, bufname, { width = opts.width })
+  for index, line in ipairs(content) do
+    table.insert(marks, { row = index - 1, start_col = 0, end_col = #line, hl_group = hl.symbols.gray })
+  end
 
-  layout.set_buf_options(buf, win, bufname, bufname)
-  api.nvim_set_option_value("cursorline", false, { win = win })
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
+  layout.notification_layout(buf, bufname, { width = opts.width })
+  apply_marks(buf, marks, {})
 end
 
 return M

--- a/lua/kubectl/notification.lua
+++ b/lua/kubectl/notification.lua
@@ -22,6 +22,7 @@ function M.process_row(rows)
       line = string.sub(line, 1, max_width - 3)
       line = line .. "..."
     end
+
     table.insert(aligned_lines, padding .. line)
   end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -43,8 +43,8 @@ end
 
 function ResourceBuilder:fetchAsync(callback)
   notifications.Open({
-    hl.symbols.gray .. "fetching " .. "[" .. self.resource .. "]",
-    hl.symbols.gray .. "args: " .. " " .. vim.inspect(self.args),
+    "fetching " .. "[" .. self.resource .. "]",
+    "args: " .. " " .. vim.inspect(self.args),
   })
   commands.shell_command_async(self.cmd, self.args, function(data)
     self.data = data
@@ -58,7 +58,7 @@ function ResourceBuilder:decodeJson()
 
   if success then
     notifications.Add({
-      hl.symbols.gray .. "json decode successful " .. "[" .. self.resource .. "]",
+      "json decode successful " .. "[" .. self.resource .. "]",
     })
     self.data = decodedData
   end
@@ -67,7 +67,7 @@ end
 
 function ResourceBuilder:process(processFunc)
   notifications.Add({
-    hl.symbols.gray .. "processing table " .. "[" .. self.resource .. "]",
+    "processing table " .. "[" .. self.resource .. "]",
   })
   self.processedData = processFunc(self.data)
   return self
@@ -75,7 +75,7 @@ end
 
 function ResourceBuilder:sort()
   notifications.Add({
-    hl.symbols.gray .. "sorting " .. "[" .. self.resource .. "]",
+    "sorting " .. "[" .. self.resource .. "]",
   })
   local sortby = state.sortby.current_word
   if sortby ~= "" then
@@ -114,7 +114,7 @@ end
 
 function ResourceBuilder:prettyPrint(headersFunc)
   notifications.Add({
-    hl.symbols.gray .. "prettify table " .. "[" .. self.resource .. "]",
+    "prettify table " .. "[" .. self.resource .. "]",
   })
   self.prettyData, self.extmarks = tables.pretty_print(self.processedData, headersFunc())
   return self
@@ -122,7 +122,7 @@ end
 
 function ResourceBuilder:addHints(hints, include_defaults, include_context)
   notifications.Add({
-    hl.symbols.gray .. "adding hints " .. "[" .. self.resource .. "]",
+    "adding hints " .. "[" .. self.resource .. "]",
   })
   self.header.data, self.header.marks = tables.generateHeader(hints, include_defaults, include_context)
   return self
@@ -138,7 +138,7 @@ function ResourceBuilder:display(filetype, title, cancellationToken)
     return
   end
   notifications.Add({
-    hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
+    "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
   actions.buffer(find.filter_line(self.prettyData, self.filter, 2), self.extmarks, filetype, { title = title, header = self.header })
@@ -150,7 +150,7 @@ function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)
   local displayData = usePrettyData and self.prettyData or self.data
 
   notifications.Add({
-    hl.symbols.gray .. "display data " .. "[" .. self.resource .. "]",
+    "display data " .. "[" .. self.resource .. "]",
   })
   notifications.Close()
   actions.floating_buffer(displayData, self.extmarks, filetype, { title = title, syntax = syntax, header = self.header })


### PR DESCRIPTION
Since there seems to be a bug in using winblend when overlapping other text in the background and we have moved to marks for point of interest we will also use it for the notifications