### PR TITLE
fix: floats close not working

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -181,7 +181,9 @@ function M.floating_buffer(content, marks, filetype, opts)
   set_buffer_lines(buf, opts.header.data, content)
 
   local win = layout.float_layout(buf, filetype, opts.title or "")
-  vim.keymap.set("n", "q", vim.cmd.close, { buffer = buf, silent = true })
+  vim.keymap.set("n", "q", function()
+    vim.cmd("bdelete")
+  end, { buffer = buf, silent = true })
 
   layout.set_buf_options(buf, win, filetype, opts.syntax or filetype, bufname)
   apply_marks(buf, marks, opts.header)

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -46,11 +46,12 @@ function M.tailLogs(pod, ns)
   local args = { "logs", "--follow", "--since=1s", pod, "-c", M.selection, "-n", ns }
   local handle = commands.shell_command_async("kubectl", args, nil, handle_output)
 
-  vim.notify("Following : " .. pod .. "-c " .. M.selection, vim.log.levels.INFO)
+  vim.notify("Start tailing : " .. pod .. "-c " .. M.selection, vim.log.levels.INFO)
   vim.api.nvim_create_autocmd("BufWinLeave", {
     buffer = buf,
     callback = function()
       handle:kill(2)
+      vim.notify("Stopped tailing : " .. pod .. "-c " .. M.selection, vim.log.levels.INFO)
     end,
   })
 end

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -63,7 +63,6 @@ end
 
 function M.logs(pod, ns)
   ResourceBuilder:new("containerLogs")
-    :displayFloat("k8s_container_logs", pod .. " - " .. M.selection, "less")
     :setCmd(
       { "{{BASE}}/api/v1/namespaces/" .. ns .. "/pods/" .. pod .. "/log/?container=" .. M.selection .. "&pretty=true" },
       "curl"


### PR DESCRIPTION
Since we try to preload the empty buffer, it seems that q stopped working correctly.
Changing from vim.cmd.close to vim.cmd.bdelete closes the window as well and thus the preloaded buffer.
Nested floats such as container -> logs doesn't work so removed the pre loading of that buffer