### PR TITLE
feat: apply current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,20 +48,18 @@ Install the plugin with your preferred package manager:
 return {
   {
     "ramilito/kubectl.nvim",
-    keys = {
-      {
-        "<leader>k",
-        function()
-          require("kubectl").open()
-        end,
-        desc = "Kubectl",
-      },
-    },
     config = function()
       require("kubectl").setup()
     end,
   },
 }
+```
+
+## ⌨️ Keymaps
+
+```lua
+-- Recommended is to have the same open mapping as your close (```<leader>k```) the plugin for a toggle effect.
+vim.keymap.set("n", "<leader>k", '<cmd>lua require("kubectl").open()<cr>', { noremap = true, silent = true })
 ```
 
 ## ⚙️ Configuration

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Processes kubectl outputs to enable vim-like navigation in a buffer for your clu
 </details>
 <details>
   <summary>Exec into containers</summary>
+  <sub>In the pod view, select a pod by pressing <code><cr></code> and then again <code><cr></code> on the container you want to exec into</sub>
   <img src="https://github.com/Ramilito/kubectl.nvim/assets/17252601/24e15963-bfd2-43a5-9e35-9d33cf5d976e" width="700px">
 </details>
 <details>
   <summary>Sort by headers</summary>
+    <sub>By moving the cursor to a header word and pressing <code>s</code></sub>
   <img src="https://github.com/Ramilito/kubectl.nvim/assets/17252601/9f96e943-eda4-458e-a4ba-cf23e0417963" width="700px">
 </details>
 <details>
@@ -31,8 +33,9 @@ Processes kubectl outputs to enable vim-like navigation in a buffer for your clu
   <img src="https://github.com/user-attachments/assets/52662db4-698b-4059-a5a2-2c9ddfe8d146" width="700px">
 </details>
    
-## ⚡️ Requ</code>red Dependencies
+## ⚡️ Required Dependencies
 - kubectl
+- curl
 - neovim >= 0.10
  
 ## ⚡️ Optional Dependencies
@@ -106,15 +109,8 @@ vim.keymap.set("n", "<leader>k", '<cmd>lua require("kubectl").open()<cr>', { nor
 
 ### Startup
 
-No startup impact since we load on demand.
-
-## Usage
-
-### Sorting
-By moving the cursor to a header word and pressing ```s```
-
-### Exec into container
-In the pod view, select a pod by pressing ```<cr>``` and then again ```<cr>``` on the container you want to exec into
+The setup function only adds ~1ms to startup.
+We use kubectl proxy and curl to reduce latency.
 
 ## Versioning
 > [!WARNING]
@@ -122,4 +118,4 @@ In the pod view, select a pod by pressing ```<cr>``` and then again ```<cr>``` o
 > in cases where it is deemed necessary.
 
 ## Motivation
-This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for filebrowsing. I might add a way to act on the cluster (delete resources, edit) in the future, not sure yet.
+This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for file browsing.

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -131,7 +131,7 @@ function M.confirmation_buffer(prompt, filetype, onConfirm, opts)
 
   local layout_opts = {
     size = {
-      width = #prompt + 4,
+      width = #prompt + #filetype + 4,
       height = #content + 1,
       col = (vim.api.nvim_win_get_width(0) - #prompt + 2) * 0.5,
       row = (vim.api.nvim_win_get_height(0) - #content + 1) * 0.5,

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -3,7 +3,7 @@ local M = {}
 --- Execute a shell command synchronously
 --- @param cmd string The command to execute
 --- @param args string[] The arguments for the command
---- @param opts { env: string, on_stdout: function }|nil The arguments for the command
+--- @param opts { env: string, on_stdout: function, stdin: string }|nil The arguments for the command
 --- @return string The result of the command execution
 function M.shell_command(cmd, args, opts)
   opts = opts or {}
@@ -15,6 +15,7 @@ function M.shell_command(cmd, args, opts)
   local job = vim.system(args, {
     text = true,
     env = opts.env,
+    stdin = opts.stdin,
     stdout = function(_, data)
       if data then
         result = result .. data
@@ -45,12 +46,15 @@ end
 --- @param args string[] The arguments for the command
 --- @param on_exit? function The callback function to execute when the command exits
 --- @param on_stdout? function The callback function to execute when there is stdout output (optional)
-function M.shell_command_async(cmd, args, on_exit, on_stdout)
+--- @param opts { env: string, stdin: string }|nil The arguments for the command
+function M.shell_command_async(cmd, args, on_exit, on_stdout, opts)
+  opts = opts or {}
   local result = ""
   table.insert(args, 1, cmd)
 
   local handle = vim.system(args, {
     text = true,
+    stdin = opts.stdin,
     stdout = function(err, data)
       if err then
         return

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -66,7 +66,7 @@ end
 function M.float_layout(buf, filetype, title, opts)
   opts = opts or {}
   local size = opts.size or {}
-  if filetype then
+  if filetype ~= "" then
     title = filetype .. " - " .. (title or "")
   end
 

--- a/lua/kubectl/completion.lua
+++ b/lua/kubectl/completion.lua
@@ -133,8 +133,13 @@ end
 
 function M.apply()
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local file_name = vim.api.nvim_buf_get_name(0)
   local content = table.concat(lines, "\n")
-  commands.shell_command_async("kubectl", { "apply", "-f", "-" }, nil, nil, { stdin = content })
+  buffers.confirmation_buffer("Apply " .. file_name .. "?", "", function(confirm)
+    if confirm then
+      commands.shell_command_async("kubectl", { "apply", "-f", "-" }, nil, nil, { stdin = content })
+    end
+  end)
 end
 
 return M

--- a/lua/kubectl/completion.lua
+++ b/lua/kubectl/completion.lua
@@ -131,4 +131,10 @@ function M.diff(path)
   end
 end
 
+function M.apply()
+  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local content = table.concat(lines, "\n")
+  commands.shell_command_async("kubectl", { "apply", "-f", "-" }, nil, nil, { stdin = content })
+end
+
 return M

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -57,6 +57,8 @@ function M.setup(options)
       end
     elseif opts.fargs[1] == "diff" then
       completion.diff(opts.fargs[2])
+    elseif opts.fargs[1] == "apply" then
+      completion.apply()
     else
       view.UserCmd(opts.fargs)
     end

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -28,8 +28,8 @@ function M.register()
         local ns, name = tables.getCurrentSelection(1, 2)
         if name and ns then
           buffers.confirmation_buffer(
-            "Do you want to delete: " .. buf_name .. "/" .. name .. " in namespace: " .. ns,
-            "yaml",
+            "run - kubectl delete " .. string.lower(buf_name) .. "/" .. name .. " -ns " .. ns,
+            "",
             function(confirm)
               if confirm then
                 commands.shell_command_async("kubectl", { "delete", buf_name, name, "-n", ns })

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -22,10 +22,11 @@ ResourceBuilder.__index = ResourceBuilder
 ---@param args table? The arguments for the resource
 ---@return ResourceBuilder
 function ResourceBuilder:new(resource, args)
+  self = setmetatable({}, ResourceBuilder)
   self.resource = resource
   self.args = args or {}
   self.header = { data = nil, marks = nil }
-  return setmetatable({}, ResourceBuilder)
+  return self
 end
 
 --- Sets a command for the ResourceBuilder instance.

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -15,6 +15,7 @@ function M.Hints(headers)
     { key = "<C-e>", desc = "Edit resource" },
     { key = "<C-f>", desc = "Filter on a phrase" },
     { key = "<C-n>", desc = "Change namespace" },
+    { key = "<C-d>", desc = "Delete resource" },
     { key = "<bs> ", desc = "Go up a level" },
     { key = "<R>  ", desc = "Refresh view" },
     { key = "<1>  ", desc = "Deployments" },


### PR DESCRIPTION
add apply command for current buffer (file has to exist, we use edit for inline modification so should be fine)
add ability to optionally write to shell commands
add delete resource global command

Bonus:
fix confirmation prompt width
fix printing - when no filetype assigned
fix when we create new resourcebuilder we were getting artifacts of previous instantiation 
update readme to use keymap instead of lazyloading on key, allows for using kubectl commands without opening the plugin
update readme by removing usage section and using the feature section to explain details