### PR TITLE
feat: port forward mark and stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Processes kubectl outputs to enable vim-like navigation in a buffer for your clu
   <summary>Diff view: <code>:Kubectl diff (path)</code></summary>
   <img src="https://github.com/user-attachments/assets/52662db4-698b-4059-a5a2-2c9ddfe8d146" width="700px">
 </details>
-   
+<details>
+  <summary>Port forward</summary>
+  <img src="https://github.com/user-attachments/assets/d3957b71-584e-45f2-9256-4fb5d16d6b5f" width="700px">
+</details>
+
 ## ⚡️ Required Dependencies
 - kubectl
 - curl

--- a/ftplugin/k8s_pod_pf.lua
+++ b/ftplugin/k8s_pod_pf.lua
@@ -1,19 +1,21 @@
+local commands = require("kubectl.actions.commands")
+local pod_view = require("kubectl.views.pods")
 local tables = require("kubectl.utils.tables")
 
---- Set key mappings for the buffer
 local function set_keymaps(bufnr)
   vim.api.nvim_buf_set_keymap(bufnr, "n", "gk", "", {
     noremap = true,
     silent = true,
     desc = "Kill port forward",
     callback = function()
-      local pid = tables.getCurrentSelection(1)
-      print(pid)
+      local pid, resource = tables.getCurrentSelection(1, 2)
+      vim.notify("Killing port forward for resource " .. resource .. " with pid: " .. pid)
+      commands.shell_command("kill", { pid })
+      pod_view.PodPF()
     end,
   })
 end
 
---- Initialize the module
 local function init()
   set_keymaps(0)
 end

--- a/ftplugin/k8s_pod_pf.lua
+++ b/ftplugin/k8s_pod_pf.lua
@@ -1,0 +1,21 @@
+local tables = require("kubectl.utils.tables")
+
+--- Set key mappings for the buffer
+local function set_keymaps(bufnr)
+  vim.api.nvim_buf_set_keymap(bufnr, "n", "gk", "", {
+    noremap = true,
+    silent = true,
+    desc = "Kill port forward",
+    callback = function()
+      local pid = tables.getCurrentSelection(1)
+      print(pid)
+    end,
+  })
+end
+
+--- Initialize the module
+local function init()
+  set_keymaps(0)
+end
+
+init()

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -106,6 +106,14 @@ local function set_keymaps(bufnr)
     end,
   })
 
+  api.nvim_buf_set_keymap(bufnr, "n", "gP", "", {
+    noremap = true,
+    silent = true,
+    desc = "View Port Forwards",
+    callback = function()
+      pod_view.PodPF()
+    end,
+  })
   api.nvim_buf_set_keymap(bufnr, "n", "gp", "", {
     noremap = true,
     silent = true,

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -17,12 +17,13 @@ local function set_keymaps(bufnr)
     desc = "Help",
     callback = function()
       view.Hints({
-        { key = "<gl>", desc = "Shows logs for all containers in pod" },
         { key = "<gd>", desc = "Describe selected pod" },
+        { key = "<gk>", desc = "Kill pod" },
+        { key = "<gl>", desc = "Shows logs for all containers in pod" },
+        { key = "<gp>", desc = "Port forward" },
+        { key = "<gP>", desc = "View active Port forwards" },
         { key = "<gu>", desc = "Show resources used" },
         { key = "<enter>", desc = "Opens container view" },
-        { key = "<shift-f>", desc = "Port forward" },
-        { key = "<gk>", desc = "Kill pod" },
       })
     end,
   })

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -63,7 +63,9 @@ local function apply_marks(bufnr, marks, header)
         local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, ns_id, start_row, mark.start_col, {
           end_line = start_row,
           end_col = mark.end_col,
-          hl_group = mark.hl_group,
+          hl_group = mark.hl_group or nil,
+          virt_text = mark.virt_text or nil,
+          virt_text_pos = mark.virt_text_pos or nil,
         })
         if mark.row == 0 and ok then
           state.content_row_start = start_row + 1

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -34,7 +34,7 @@ function M.shell_command(cmd, args, opts)
   -- Wait for the job to complete
   local exit_code = job:wait()
 
-  if exit_code.code ~= 0 then
+  if exit_code.code ~= 0 and error_result ~= "" then
     vim.notify(error_result, vim.log.levels.ERROR)
   end
 

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -34,7 +34,7 @@ function M.shell_command(cmd, args, opts)
   -- Wait for the job to complete
   local exit_code = job:wait()
 
-  if exit_code ~= 0 then
+  if exit_code.code ~= 0 then
     vim.notify(error_result, vim.log.levels.ERROR)
   end
 

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -102,6 +102,19 @@ function M.execute_shell_command(cmd, args)
   return result
 end
 
+--- Execute a shell command with a pipe asynchronously using vim.system
+--- @param cmd string The shell command to execute
+--- @param callback function The callback function to handle the result of the command execution
+function M.execute_shell_command_async(cmd, callback)
+  vim.system({ "sh", "-c", cmd }, { text = true }, function(obj)
+    if obj.code == 0 then
+      callback(nil, obj.stdout)
+    else
+      callback("Failed to execute command: " .. cmd, nil)
+    end
+  end)
+end
+
 --- Execute a command in a terminal
 --- @param cmd string The command to execute
 --- @param args string|string[] The arguments for the command

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -102,19 +102,6 @@ function M.execute_shell_command(cmd, args)
   return result
 end
 
---- Execute a shell command with a pipe asynchronously using vim.system
---- @param cmd string The shell command to execute
---- @param callback function The callback function to handle the result of the command execution
-function M.execute_shell_command_async(cmd, callback)
-  vim.system({ "sh", "-c", cmd }, { text = true }, function(obj)
-    if obj.code == 0 then
-      callback(nil, obj.stdout)
-    else
-      callback("Failed to execute command: " .. cmd, nil)
-    end
-  end)
-end
-
 --- Execute a command in a terminal
 --- @param cmd string The command to execute
 --- @param args string|string[] The arguments for the command

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -51,7 +51,7 @@ local function getPodStatus(phase)
   return status
 end
 
-function M.getPortForwards(marks, data, port_forwards)
+function M.setPortForwards(marks, data, port_forwards)
   for _, pf in ipairs(port_forwards) do
     for row, line in ipairs(data) do
       local col = line:find(pf.resource, 1, true)

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -51,6 +51,26 @@ local function getPodStatus(phase)
   return status
 end
 
+function M.getPortForwards(marks, data, port_forwards)
+  for _, pf in ipairs(port_forwards) do
+    for row, line in ipairs(data) do
+      local col = line:find(pf.resource, 1, true)
+
+      if col then
+        local mark = {
+          row = row - 1,
+          start_col = col + #pf.resource - 1,
+          end_col = col + #pf.resource - 1 + 3,
+          virt_text = { { " ⇄ ", hl.symbols.success } },
+          virt_text_pos = "overlay",
+        }
+        table.insert(marks, #marks, mark)
+      end
+    end
+  end
+  return marks
+end
+
 function M.processRow(rows)
   local data = {}
   local currentTime = time.currentTime()

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -53,16 +53,20 @@ local function getPodStatus(phase)
 end
 
 function M.getPortForwards(port_forwards)
-  if vim.fn.has("win32") ~= 1 then
-    commands.execute_shell_command_async("ps -eo args | grep '[k]ubectl port-forward'", function(_, data)
-      for _, line in ipairs(vim.split(data, "\n")) do
-        local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
-        if resource and port then
-          table.insert(port_forwards, { resource = resource, port = port })
-        end
-      end
-    end)
+  if vim.fn.has("win32") == 1 then
+    return
   end
+  commands.execute_shell_command_async("ps -eo args | grep '[k]ubectl port-forward'", function(_, data)
+    if not data then
+      return
+    end
+    for _, line in ipairs(vim.split(data, "\n")) do
+      local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
+      if resource and port then
+        table.insert(port_forwards, { resource = resource, port = port })
+      end
+    end
+  end)
 end
 
 function M.setPortForwards(marks, data, port_forwards)

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -70,7 +70,7 @@ function M.getPortForwards(port_forwards, async)
   end
 
   if async then
-    commands.execute_shell_command_async("ps -eo args | grep '[k]ubectl port-forward'", function(_, data)
+    commands.shell_command_async("sh", { "-c", "ps -eo args | grep '[k]ubectl port-forward'" }, function(data)
       if not data then
         return
       end

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -133,7 +133,6 @@ function M.PodPF()
   end
 
   builder.prettyData, builder.extmarks = tables.pretty_print(data, { "PID", "RESOURCE", "PORT" })
-  print(vim.inspect(builder.prettyData))
   builder
     :addHints({ { key = "<gk>", desc = "Kill PF" } }, false, false, false)
     :displayFloat("k8s_pod_pf", "Port forwards", "", true)

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -10,7 +10,7 @@ function M.View(cancellationToken)
   local pfs = {}
   if vim.fn.has("win32") ~= 1 then
     local port_forwards = {}
-    commands.execute_shell_command_async("ps -A -eo args | grep '[k]ubectl port-forward'", function(error, data)
+    commands.execute_shell_command_async("ps -eo args | grep '[k]ubectl port-forward'", function(_, data)
       for _, line in ipairs(vim.split(data, "\n")) do
         local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
         if resource and port then
@@ -31,7 +31,7 @@ function M.View(cancellationToken)
     :fetchAsync(function(self)
       self:decodeJson()
       self:process(definition.processRow):sort():prettyPrint(definition.getHeaders)
-      definition.getPortForwards(self.extmarks, self.prettyData, pfs)
+      definition.setPortForwards(self.extmarks, self.prettyData, pfs)
       vim.schedule(function()
         self
           :addHints({

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -11,7 +11,7 @@ function M.View(cancellationToken)
   if vim.fn.has("win32") ~= 1 then
     local port_forwards = {}
     commands.shell_command_async("ps", { "-A", "-eo", "args" }, function(data)
-      for line in data:gmatch("[^\r\n]+") do
+      for _, line in ipairs(vim.split(data, "\n")) do
         if line:find("kubectl port%-forward") then
           local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
           if resource and port then

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -2,7 +2,6 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.pods.definition")
-local timeme = require("kubectl.utils.timeme")
 
 local M = {}
 M.selection = {}
@@ -18,7 +17,6 @@ function M.View(cancellationToken)
       self:decodeJson()
       self:process(definition.processRow):sort():prettyPrint(definition.getHeaders)
       if vim.fn.has("win32") ~= 1 then
-        timeme.start()
         local port_forwards = {}
         local result = commands.execute_shell_command("ps", "-A -eo args | grep '[k]ubectl port-forward'")
         local pfs = vim.split(result, "\n")
@@ -29,7 +27,6 @@ function M.View(cancellationToken)
           end
         end
         definition.getPortForwards(self.extmarks, self.prettyData, port_forwards)
-        timeme.stop()
       end
       vim.schedule(function()
         self

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -26,6 +26,7 @@ function M.View(cancellationToken)
             { key = "<gk>", desc = "kill pod" },
           }, true, true, true)
           :display("k8s_pods", "Pods", cancellationToken)
+        M.PortForward()
       end)
     end)
 end
@@ -90,6 +91,52 @@ function M.PodLogs()
           :displayFloat("k8s_pod_logs", M.selection.pod, "less")
       end)
     end)
+end
+
+function M.PortForward()
+  local function on_exit(result)
+    local port_forwards = {}
+
+    for line in result:gmatch("[^\r\n]+") do
+      if line:find("kubectl port%-forward") then
+        local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
+        if resource and port then
+          table.insert(port_forwards, { resource = resource, port = port })
+        end
+      end
+    end
+
+    if #port_forwards > 0 then
+      vim.schedule(function()
+        local hl = require("kubectl.actions.highlight")
+        local bufnr = vim.api.nvim_get_current_buf()
+        local ns_id = vim.api.nvim_create_namespace("pod_pf")
+        vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        for _, pf in ipairs(port_forwards) do
+          for row, line in ipairs(lines) do
+            local col = line:find(pf.resource, 1, true)
+            if col then
+              vim.api.nvim_buf_set_extmark(
+                bufnr,
+                ns_id,
+                row - 1,
+                col + #pf.resource - 1,
+                { virt_text = { { " ⇄ ", hl.symbols.success } }, virt_text_pos = "overlay" }
+              )
+            end
+          end
+        end
+      end)
+    end
+  end
+
+  -- TODO: Support windows?
+  if vim.fn.has("win32") ~= 1 then
+    local args = { "-eo", "args" }
+    commands.shell_command_async("ps", args, on_exit)
+  end
 end
 
 function M.Edit(name, namespace)

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -10,13 +10,11 @@ function M.View(cancellationToken)
   local pfs = {}
   if vim.fn.has("win32") ~= 1 then
     local port_forwards = {}
-    commands.shell_command_async("ps", { "-A", "-eo", "args" }, function(data)
+    commands.execute_shell_command_async("ps -A -eo args | grep '[k]ubectl port-forward'", function(error, data)
       for _, line in ipairs(vim.split(data, "\n")) do
-        if line:find("kubectl port%-forward") then
-          local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
-          if resource and port then
-            table.insert(port_forwards, { resource = resource, port = port })
-          end
+        local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
+        if resource and port then
+          table.insert(port_forwards, { resource = resource, port = port })
         end
       end
 

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -9,7 +9,7 @@ M.selection = {}
 
 function M.View(cancellationToken)
   local pfs = {}
-  definition.getPortForwards(pfs)
+  definition.getPortForwards(pfs, true)
   ResourceBuilder:new("pods")
     :setCmd({
       "{{BASE}}/api/v1/{{NAMESPACE}}pods?pretty=false",
@@ -118,28 +118,26 @@ end
 
 function M.PodPF()
   local pfs = {}
-  definition.getPortForwards(pfs)
+  pfs = definition.getPortForwards(pfs, false)
 
-  vim.defer_fn(function()
-    local builder = ResourceBuilder:new("desc")
+  local builder = ResourceBuilder:new("desc")
 
-    builder.data = {}
-    builder.extmarks = {}
-    for index, value in ipairs(pfs) do
-      local line = value.resource .. " | " .. value.port
-      table.insert(builder.data, line)
-      table.insert(
-        builder.extmarks,
-        { row = index - 1, start_col = 0, end_col = #value.resource, hl_group = hl.symbols.success }
-      )
-      table.insert(
-        builder.extmarks,
-        { row = index - 1, start_col = #line - #value.port, end_col = #line, hl_group = hl.symbols.pending }
-      )
-    end
+  builder.data = {}
+  builder.extmarks = {}
+  for index, value in ipairs(pfs) do
+    local line = value.resource .. " | " .. value.port
+    table.insert(builder.data, line)
+    table.insert(
+      builder.extmarks,
+      { row = index - 1, start_col = 0, end_col = #value.resource, hl_group = hl.symbols.success }
+    )
+    table.insert(
+      builder.extmarks,
+      { row = index - 1, start_col = #line - #value.port, end_col = #line, hl_group = hl.symbols.pending }
+    )
+  end
 
-    builder:displayFloat("", "Port forwards", "", false)
-  end, 100)
+  builder:displayFloat("", "Port forwards", "", false)
 end
 
 return M

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -8,20 +8,7 @@ M.selection = {}
 
 function M.View(cancellationToken)
   local pfs = {}
-  if vim.fn.has("win32") ~= 1 then
-    local port_forwards = {}
-    commands.execute_shell_command_async("ps -eo args | grep '[k]ubectl port-forward'", function(_, data)
-      for _, line in ipairs(vim.split(data, "\n")) do
-        local resource, port = line:match("pods/([^%s]+)%s+(%d+:%d+)")
-        if resource and port then
-          table.insert(port_forwards, { resource = resource, port = port })
-        end
-      end
-
-      pfs = port_forwards
-    end)
-  end
-
+  definition.getPortForwards(pfs)
   ResourceBuilder:new("pods")
     :setCmd({
       "{{BASE}}/api/v1/{{NAMESPACE}}pods?pretty=false",

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -18,8 +18,7 @@ function M.View(cancellationToken)
       "\n",
     }, "curl")
     :fetchAsync(function(self)
-      self:decodeJson()
-      self:process(definition.processRow):sort():prettyPrint(definition.getHeaders)
+      self:decodeJson():process(definition.processRow):sort():prettyPrint(definition.getHeaders)
       vim.schedule(function()
         definition.setPortForwards(self.extmarks, self.prettyData, pfs)
         self

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -28,7 +28,8 @@ function M.View(cancellationToken)
             { key = "<gd>", desc = "describe" },
             { key = "<gu>", desc = "usage" },
             { key = "<enter>", desc = "containers" },
-            { key = "<gp>", desc = "port forward" },
+            { key = "<gp>", desc = "PF" },
+            { key = "<gP>", desc = "view PF" },
             { key = "<gk>", desc = "kill pod" },
           }, true, true, true)
           :display("k8s_pods", "Pods", cancellationToken)

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -19,9 +19,8 @@ function M.View(cancellationToken)
     :fetchAsync(function(self)
       self:decodeJson()
       self:process(definition.processRow):sort():prettyPrint(definition.getHeaders)
-
-      definition.setPortForwards(self.extmarks, self.prettyData, pfs)
       vim.schedule(function()
+        definition.setPortForwards(self.extmarks, self.prettyData, pfs)
         self
           :addHints({
             { key = "<gl>", desc = "logs" },


### PR DESCRIPTION
- [x] Add a symbol and hl to display where a pf exists
- [x]  When killing a pod, also close the pf
- [x] Add way to stop pf without killing the resource

You can now use gP to list all active port-forwards and close them without affecting the underlying service


Solves #66 


demo: 

![pf](https://github.com/user-attachments/assets/d3957b71-584e-45f2-9256-4fb5d16d6b5f)
