### PR TITLE
feat: use api-resources and fallback view in user_cmd

### DIFF
--- a/lua/kubectl/completion.lua
+++ b/lua/kubectl/completion.lua
@@ -63,21 +63,12 @@ function M.user_command_completion(_, cmd)
   end
   if #parts == 1 then
     return top_level_commands
-  end
-end
+  elseif #parts == 2 and parts[2] == "get" then
+    local view = require("kubectl.views")
+    local data = vim.split(view.cached_api_resources.values, "\n")
 
---- Find the view command
---- @param arg string The argument to match with the views
---- @param views ViewTable
---- @return function|nil view The view function if found, nil otherwise
-function M.find_view_command(arg, views)
-  for k, v in pairs(views) do
-    if vim.tbl_contains(v, arg) then
-      local view = require("kubectl.views." .. k)
-      return view.View
-    end
+    return data
   end
-  return nil
 end
 
 --- Returns a list of context-names

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -49,9 +49,14 @@ function M.setup(options)
   vim.api.nvim_create_user_command("Kubectl", function(opts)
     local view = require("kubectl.views")
     if opts.fargs[1] == "get" then
-      local cmd = completion.find_view_command(opts.fargs[2], M.views)
-      if cmd then
-        cmd()
+      if #opts.fargs == 2 then
+        local ok, x_view = pcall(require, "kubectl.views." .. opts.fargs[2])
+        if ok then
+          pcall(x_view.View)
+        else
+          view = require("kubectl.views.fallback")
+          view.View(nil, opts.fargs[2])
+        end
       else
         view.UserCmd(opts.fargs)
       end


### PR DESCRIPTION
Solves #138
Uses the cached api-resources to autocomplete resources when typing Kubectl get <TAB>.
Uses fallback view if we don't support the view yet