### PR TITLE
fix: filter ignore our symbol key

### DIFF
--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -29,7 +29,9 @@ local function is_in_table(tbl, str)
   if str == nil then
     return false
   end
-  for _, value in pairs(tbl) do
+
+  local lowered_str = str:lower()
+
   for key, value in pairs(tbl) do
     if key == "symbol" then
       return false
@@ -38,7 +40,7 @@ local function is_in_table(tbl, str)
       if is_in_table(value, str) then
         return true
       end
-    elseif tostring(value):lower():match(str:lower()) then
+    elseif value:lower():match(lowered_str) then
       return true
     end
   end

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -40,7 +40,7 @@ local function is_in_table(tbl, str)
       if is_in_table(value, str) then
         return true
       end
-    elseif value:lower():match(lowered_str) then
+    elseif tostring(value):lower():match(lowered_str) then
       return true
     end
   end
@@ -53,21 +53,17 @@ end
 ---@param startAt number
 ---@return table[]
 function M.filter_line(array, pattern, startAt)
-  local filtered_array = {}
   if not pattern then
     return array
   end
   startAt = startAt or 1
+  local filtered_array = {}
 
-  if array then
-    for index = 1, startAt - 1 do
-      table.insert(filtered_array, array[index])
-    end
-    for index = startAt, #array do
-      local line = array[index]
-      if is_in_table(line, pattern) then
-        table.insert(filtered_array, line)
-      end
+  -- Filter the array starting from startAt
+  for index = startAt, #array do
+    local line = array[index]
+    if is_in_table(line, pattern) then
+      table.insert(filtered_array, line)
     end
   end
 

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -30,6 +30,10 @@ local function is_in_table(tbl, str)
     return true
   end
   for _, value in pairs(tbl) do
+  for key, value in pairs(tbl) do
+    if key == "symbol" then
+      return false
+    end
     if type(value) == "table" then
       if is_in_table(value, str) then
         return true

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -27,7 +27,7 @@ end
 ---@return boolean
 local function is_in_table(tbl, str)
   if str == nil then
-    return true
+    return false
   end
   for _, value in pairs(tbl) do
   for key, value in pairs(tbl) do


### PR DESCRIPTION
The filter was not acting correct when searching for "kube" something since we have a value for the highlighting associated with a value that contains "kube".
Ignoring that key in our filter now and also did some refactoring for performance and removed redundant loop