### PR TITLE
feat: separate buffer and content creation

### DIFF
--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -87,7 +87,7 @@ local function set_keymaps(bufnr)
 
       if name and ns then
         local port_forwards = {}
-        root_definition.getPortForwards(port_forwards, false, "pods")
+        root_definition.getPFData(port_forwards, false, "pods")
         for _, pf in ipairs(port_forwards) do
           if pf.resource == name then
             vim.notify("Killing port forward for " .. pf.resource)

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -220,6 +220,38 @@ function M.floating_dynamic_buffer(filetype, title, opts)
     end,
   })
 
+  vim.api.nvim_buf_attach(buf, false, {
+    on_lines = function(
+      _, -- use nil as first argument (since it is buffer handle)
+      buf_nr, -- buffer number
+      changedtick, -- buffer changedtick
+      firstline, -- first line number of the change (0-indexed)
+      lastline, -- last line number of the change
+      new_lastline -- last line number after the change
+    )
+      if lastline ~= new_lastline then
+        local win_config = vim.api.nvim_win_get_config(win)
+
+        local rows = vim.api.nvim_buf_line_count(buf_nr)
+        -- Calculate the maximum width (number of columns of the widest line)
+        local max_columns = 0
+        local lines = vim.api.nvim_buf_get_lines(buf_nr, 0, rows, false)
+
+        for _, line in ipairs(lines) do
+          local line_width = vim.api.nvim_strwidth(line)
+          if line_width > max_columns then
+            max_columns = line_width
+          end
+        end
+
+        win_config.height = rows
+        win_config.width = max_columns
+
+        vim.api.nvim_win_set_config(win, win_config)
+      end
+    end,
+  })
+
   return buf
 end
 

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -198,24 +198,23 @@ function M.floating_dynamic_buffer(filetype, title, opts)
   local bufname = title or "kubectl_dynamic_float"
   opts.header = opts.header or {}
   local buf = vim.fn.bufnr(bufname, false)
-
+  local win
   if buf == -1 then
     buf = create_buffer(bufname)
+    win = layout.float_dynamic_layout(buf, filetype, title or "")
+    layout.set_buf_options(buf, win, filetype, opts.syntax or filetype, bufname)
   end
 
-  local win = layout.float_dynamic_layout(buf, filetype, title or "")
   vim.keymap.set("n", "q", function()
-    vim.cmd("bdelete")
+    vim.api.nvim_buf_delete(buf, { force = false })
   end, { buffer = buf, silent = true })
-
-  layout.set_buf_options(buf, win, filetype, opts.syntax or filetype, bufname)
 
   vim.api.nvim_buf_attach(buf, false, {
     on_lines = function(
       _, -- use nil as first argument (since it is buffer handle)
       buf_nr, -- buffer number
-      _, -- buffer changedtick
-      _, -- first line number of the change (0-indexed)
+      changedtick, -- buffer changedtick
+      firstline, -- first line number of the change (0-indexed)
       lastline, -- last line number of the change
       new_lastline -- last line number after the change
     )
@@ -223,7 +222,6 @@ function M.floating_dynamic_buffer(filetype, title, opts)
         local win_config = vim.api.nvim_win_get_config(win)
 
         local rows = vim.api.nvim_buf_line_count(buf_nr)
-
         -- Calculate the maximum width (number of columns of the widest line)
         local max_columns = 100
         local lines = vim.api.nvim_buf_get_lines(buf_nr, 0, rows, false)

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -199,6 +199,7 @@ function M.floating_dynamic_buffer(filetype, title, opts)
   opts.header = opts.header or {}
   local buf = vim.fn.bufnr(bufname, false)
   local win
+
   if buf == -1 then
     buf = create_buffer(bufname)
     win = layout.float_dynamic_layout(buf, filetype, title or "")

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -258,6 +258,7 @@ end
 --- @param buf number: Buffer number
 --- @param opts { content: table, marks: table,  header: { data: table }}
 function M.set_content(buf, opts)
+  opts.header = opts.header or {}
   set_buffer_lines(buf, opts.header.data, opts.content)
   M.apply_marks(buf, opts.marks, opts.header)
 

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -203,7 +203,7 @@ function M.floating_dynamic_buffer(filetype, title, opts)
     buf = create_buffer(bufname)
   end
 
-  local win = layout.float_layout(buf, filetype, title or "")
+  local win = layout.float_dynamic_layout(buf, filetype, title or "")
   vim.keymap.set("n", "q", function()
     vim.cmd("bdelete")
   end, { buffer = buf, silent = true })
@@ -234,7 +234,7 @@ function M.floating_dynamic_buffer(filetype, title, opts)
 
         local rows = vim.api.nvim_buf_line_count(buf_nr)
         -- Calculate the maximum width (number of columns of the widest line)
-        local max_columns = 0
+        local max_columns = 100
         local lines = vim.api.nvim_buf_get_lines(buf_nr, 0, rows, false)
 
         for _, line in ipairs(lines) do

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -210,22 +210,12 @@ function M.floating_dynamic_buffer(filetype, title, opts)
 
   layout.set_buf_options(buf, win, filetype, opts.syntax or filetype, bufname)
 
-  local group = filetype
-  vim.api.nvim_create_augroup(group, { clear = true })
-  vim.api.nvim_create_autocmd({ "BufLeave", "BufDelete" }, {
-    group = group,
-    buffer = buf,
-    callback = function()
-      vim.api.nvim_input("gr")
-    end,
-  })
-
   vim.api.nvim_buf_attach(buf, false, {
     on_lines = function(
       _, -- use nil as first argument (since it is buffer handle)
       buf_nr, -- buffer number
-      changedtick, -- buffer changedtick
-      firstline, -- first line number of the change (0-indexed)
+      _, -- buffer changedtick
+      _, -- first line number of the change (0-indexed)
       lastline, -- last line number of the change
       new_lastline -- last line number after the change
     )
@@ -233,6 +223,7 @@ function M.floating_dynamic_buffer(filetype, title, opts)
         local win_config = vim.api.nvim_win_get_config(win)
 
         local rows = vim.api.nvim_buf_line_count(buf_nr)
+
         -- Calculate the maximum width (number of columns of the widest line)
         local max_columns = 100
         local lines = vim.api.nvim_buf_get_lines(buf_nr, 0, rows, false)

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -82,6 +82,32 @@ function M.filter_layout(buf, filetype, title)
   return win
 end
 
+--- Create a float dynamic layout.
+--- @param buf integer: The buffer number.
+--- @param filetype string: The filetype for the buffer.
+--- @param title string|nil: The title for the buffer (optional).
+--- @param opts { relative: string|nil }|nil: The options for the float layout (optional).
+--- @return integer: The window number.
+function M.float_dynamic_layout(buf, filetype, title, opts)
+  opts = opts or {}
+  if filetype ~= "" then
+    title = filetype .. " - " .. (title or "")
+  end
+
+  local win = api.nvim_open_win(buf, true, {
+    relative = opts.relative or "editor",
+    style = "minimal",
+    width = 100,
+    height = 5,
+
+    col = (vim.api.nvim_win_get_width(0) - 100 + 2) * 0.5,
+    row = (vim.api.nvim_win_get_height(0) + 5) * 0.5,
+    border = "rounded",
+    title = title,
+  })
+  return win
+end
+
 --- Create a float layout.
 --- @param buf integer: The buffer number.
 --- @param filetype string: The filetype for the buffer.

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -99,9 +99,8 @@ function M.float_dynamic_layout(buf, filetype, title, opts)
     style = "minimal",
     width = 100,
     height = 5,
-
     col = (vim.api.nvim_win_get_width(0) - 100 + 2) * 0.5,
-    row = (vim.api.nvim_win_get_height(0) + 5) * 0.5,
+    row = (vim.api.nvim_win_get_height(0) - 20) * 0.5,
     border = "rounded",
     title = title,
   })

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -19,13 +19,67 @@ ResourceBuilder.__index = ResourceBuilder
 
 --- Create a new ResourceBuilder
 ---@param resource string The resource to build
----@param args table? The arguments for the resource
 ---@return ResourceBuilder
-function ResourceBuilder:new(resource, args)
+function ResourceBuilder:new(resource)
   self = setmetatable({}, ResourceBuilder)
   self.resource = resource
-  self.args = args or {}
   self.header = { data = nil, marks = nil }
+  return self
+end
+
+--- Display the data in a buffer
+---@param filetype string The filetype to use for the buffer
+---@param title string The title for the buffer
+---@param cancellationToken function The function to check for cancellation
+---@return ResourceBuilder|nil
+function ResourceBuilder:display(filetype, title, cancellationToken)
+  if cancellationToken and cancellationToken() then
+    return nil
+  end
+  notifications.Add({
+    "display data " .. "[" .. self.resource .. "]",
+  })
+  notifications.Close()
+  self.buf_nr = buffers.buffer(self.prettyData, self.extmarks, filetype, { title = title, header = self.header })
+  self:postRender()
+  return self
+end
+
+--- Display the data in a floating window
+---@param filetype string The filetype to use for the floating window
+---@param title string The title for the floating window
+---@param syntax string The syntax to use for the floating window
+---@param usePrettyData? boolean Whether to use pretty data or raw data
+---@return ResourceBuilder
+function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)
+  local displayData = usePrettyData and self.prettyData or self.data or {}
+
+  notifications.Add({
+    "display data " .. "[" .. self.resource .. "]",
+  })
+  notifications.Close()
+  self.buf_nr = buffers.floating_buffer(
+    displayData,
+    self.extmarks,
+    filetype,
+    { title = title, syntax = syntax, header = self.header }
+  )
+
+  return self
+end
+
+--- Display the data in a floating fit to size window
+---@param filetype string The filetype to use for the floating window
+---@param title string The title for the floating window
+---@param syntax? string The syntax to use for the floating window
+---@return ResourceBuilder
+function ResourceBuilder:displayFloatFit(filetype, title, syntax)
+  notifications.Add({
+    "display buffer " .. "[" .. self.resource .. "]",
+  })
+  notifications.Close()
+  self.buf_nr = buffers.floating_dynamic_buffer(filetype, title, syntax)
+
   return self
 end
 
@@ -212,44 +266,8 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context, incl
   return self
 end
 
---- Display the data in a buffer
----@param filetype string The filetype to use for the buffer
----@param title string The title for the buffer
----@param cancellationToken function The function to check for cancellation
----@return ResourceBuilder|nil
-function ResourceBuilder:display(filetype, title, cancellationToken)
-  if cancellationToken and cancellationToken() then
-    return nil
-  end
-  notifications.Add({
-    "display data " .. "[" .. self.resource .. "]",
-  })
-  notifications.Close()
-  self.buf_nr = buffers.buffer(self.prettyData, self.extmarks, filetype, { title = title, header = self.header })
-  self:postRender()
-  return self
-end
-
---- Display the data in a floating window
----@param filetype string The filetype to use for the floating window
----@param title string The title for the floating window
----@param syntax string The syntax to use for the floating window
----@param usePrettyData? boolean Whether to use pretty data or raw data
----@return ResourceBuilder
-function ResourceBuilder:displayFloat(filetype, title, syntax, usePrettyData)
-  local displayData = usePrettyData and self.prettyData or self.data or {}
-
-  notifications.Add({
-    "display data " .. "[" .. self.resource .. "]",
-  })
-  notifications.Close()
-  self.buf_nr = buffers.floating_buffer(
-    displayData,
-    self.extmarks,
-    filetype,
-    { title = title, syntax = syntax, header = self.header }
-  )
-
+function ResourceBuilder:setContent()
+  buffers.set_content(self.buf_nr, { content = self.prettyData, marks = self.extmarks, header = self.header })
   return self
 end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -77,7 +77,6 @@ function ResourceBuilder:displayFloatFit(filetype, title, syntax)
   notifications.Add({
     "display buffer " .. "[" .. self.resource .. "]",
   })
-  notifications.Close()
   self.buf_nr = buffers.floating_dynamic_buffer(filetype, title, syntax)
 
   return self
@@ -267,6 +266,7 @@ end
 function ResourceBuilder:setContent()
   buffers.set_content(self.buf_nr, { content = self.prettyData, marks = self.extmarks, header = self.header })
 
+  notifications.Close()
   return self
 end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -248,26 +248,25 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context, incl
   local count = ""
   local filter = ""
   if self.prettyData then
-    count = "[" .. #self.prettyData - 1 .. "]"
+    count = tostring(#self.prettyData - 1)
   elseif self.data then
-    count = "[" .. #self.data - 1 .. "]"
+    count = tostring(#self.data - 1)
   end
   if include_filter and state.filter ~= "" then
-    filter = " </" .. state.filter .. "> "
-  else
-    filter = " "
+    filter = state.filter
   end
   self.header.data, self.header.marks = tables.generateHeader(
     hints,
     include_defaults,
     include_context,
-    { resource = " " .. string_util.capitalize(self.resource), count = count, filter = filter }
+    { resource = string_util.capitalize(self.resource), count = count, filter = filter }
   )
   return self
 end
 
 function ResourceBuilder:setContent()
   buffers.set_content(self.buf_nr, { content = self.prettyData, marks = self.extmarks, header = self.header })
+
   return self
 end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -92,61 +92,34 @@ local function addDividerRow(divider, hints, marks)
   local text_width = win_width - vim.fn.getwininfo(win)[1].textoff
   local half_width = math.floor(text_width / 2)
 
-  local row = ""
+  local row = " "
   if divider then
     local resource = divider.resource or ""
     local count = divider.count or ""
     local filter = divider.filter or ""
     local info = resource .. count .. filter
     local padding = string.rep("―", half_width - #info / 2)
-    row = padding .. info .. padding
 
-    -- Left padding
+    local virt_text = {
+      { padding, hl.symbols.success },
+      { resource, hl.symbols.header },
+      { "[", hl.symbols.header },
+      { count },
+      { "]", hl.symbols.header },
+    }
+
+    if filter ~= "" then
+      table.insert(virt_text, { " </", hl.symbols.header })
+      table.insert(virt_text, { filter, hl.symbols.pending })
+      table.insert(virt_text, { ">", hl.symbols.header })
+    end
+    table.insert(virt_text, { padding, hl.symbols.success })
+
     table.insert(marks, {
       row = #hints,
       start_col = 0,
-      end_col = #padding,
-      hl_group = hl.symbols.success,
-    })
-
-    -- Resource
-    table.insert(marks, {
-      row = #hints,
-      start_col = #padding,
-      end_col = #padding + #resource,
-      hl_group = hl.symbols.header,
-    })
-
-    -- [ for count
-    table.insert(marks, {
-      row = #hints,
-      start_col = #padding + #resource,
-      end_col = #padding + #resource + 1,
-      hl_group = hl.symbols.header,
-    })
-
-    -- ] for count
-    table.insert(marks, {
-      row = #hints,
-      start_col = #padding + #resource + #count - 1,
-      end_col = #padding + #resource + #count,
-      hl_group = hl.symbols.header,
-    })
-
-    -- Filter
-    table.insert(marks, {
-      row = #hints,
-      start_col = #padding + #resource + #count,
-      end_col = #padding + #resource + #count + #filter,
-      hl_group = hl.symbols.pending,
-    })
-
-    -- Right padding
-    table.insert(marks, {
-      row = #hints,
-      start_col = #padding + #info,
-      end_col = #padding + #info + #padding,
-      hl_group = hl.symbols.success,
+      virt_text = virt_text,
+      virt_text_pos = "overlay",
     })
   else
     local padding = string.rep("―", half_width)
@@ -155,7 +128,11 @@ local function addDividerRow(divider, hints, marks)
       row = #hints,
       start_col = 0,
       end_col = #padding + #padding,
-      hl_group = hl.symbols.success,
+      virt_text = {
+        { padding, hl.symbols.success },
+        { padding, hl.symbols.success },
+      },
+      virt_text_pos = "overlay",
     })
   end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -102,7 +102,7 @@ local function addDividerRow(divider, hints, marks)
 
     local virt_text = {
       { padding, hl.symbols.success },
-      { resource, hl.symbols.header },
+      { " " .. resource, hl.symbols.header },
       { "[", hl.symbols.header },
       { count },
       { "]", hl.symbols.header },
@@ -113,7 +113,7 @@ local function addDividerRow(divider, hints, marks)
       table.insert(virt_text, { filter, hl.symbols.pending })
       table.insert(virt_text, { ">", hl.symbols.header })
     end
-    table.insert(virt_text, { padding, hl.symbols.success })
+    table.insert(virt_text, { " " .. padding, hl.symbols.success })
 
     table.insert(marks, {
       row = #hints,

--- a/lua/kubectl/views/definition.lua
+++ b/lua/kubectl/views/definition.lua
@@ -8,7 +8,7 @@ local M = {}
 ---@param async boolean @Indicates whether the function should run asynchronously
 ---@param kind "pods"|"svc"|"all" @What types we want to retrieve
 ---@return table[] @Returns the modified array of port forwards
-function M.getPortForwards(port_forwards, async, kind)
+function M.getPFData(port_forwards, async, kind)
   if vim.fn.has("win32") == 1 then
     return port_forwards
   end
@@ -48,6 +48,19 @@ function M.getPortForwards(port_forwards, async, kind)
   end
 
   return port_forwards
+end
+
+function M.getPFRows(pfs)
+  local data = {}
+  for _, value in ipairs(pfs) do
+    table.insert(data, {
+      pid = { value = value.pid, symbol = hl.symbols.gray },
+      type = { value = value.type, symbol = hl.symbols.info },
+      resource = { value = value.resource, symbol = hl.symbols.success },
+      port = { value = value.port, symbol = hl.symbols.pending },
+    })
+  end
+  return data
 end
 
 function M.setPortForwards(marks, data, port_forwards)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -68,7 +68,10 @@ function M.Hints(headers)
     tables.add_mark(marks, start_row + index - 1, 0, #header.key, hl.symbols.pending)
   end
 
-  buffers.floating_buffer(vim.split(table.concat(hints, ""), "\n"), marks, "k8s_hints", { title = "Hints" })
+  local buf = buffers.floating_dynamic_buffer("k8s_hints", "Hints")
+
+  local content = vim.split(table.concat(hints, ""), "\n")
+  buffers.set_content(buf, { content = content, marks = marks })
 end
 
 function M.Aliases()

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -149,36 +149,15 @@ end
 -- @return nil
 function M.PortForwards()
   local pfs = {}
-  pfs = definition.getPortForwards(pfs, false, "all")
+  pfs = definition.getPFData(pfs, false, "all")
 
-  local builder = ResourceBuilder:new("Port forward")
+  local self = ResourceBuilder:new("Port forward"):displayFloatFit("k8s_port_forwards", "Port forwards")
+  self.data = definition.getPFRows(pfs)
+  self.extmarks = {}
 
-  local data = {}
-  builder.extmarks = {}
-  for _, value in ipairs(pfs) do
-    table.insert(data, {
-      pid = { value = value.pid, symbol = hl.symbols.gray },
-      type = { value = value.type, symbol = hl.symbols.info },
-      resource = { value = value.resource, symbol = hl.symbols.success },
-      port = { value = value.port, symbol = hl.symbols.pending },
-    })
-  end
-
-  builder.prettyData, builder.extmarks = tables.pretty_print(data, { "PID", "TYPE", "RESOURCE", "PORT" })
-  builder
-    :displayFloat("k8s_port_forwards", "Port forwards", "", true)
-    :addHints({ { key = "<gk>", desc = "Kill PF" } }, false, false, false)
-    :displayFloat("k8s_port_forwards", "Port forwards", "", true)
-
-  local group = "k8s_port_forwards"
-  vim.api.nvim_create_augroup(group, { clear = true })
-  vim.api.nvim_create_autocmd({ "BufLeave", "BufDelete" }, {
-    group = group,
-    buffer = builder.buf_nr,
-    callback = function()
-      vim.api.nvim_input("gr")
-    end,
-  })
+  self.prettyData, self.extmarks = tables.pretty_print(self.data, { "PID", "TYPE", "RESOURCE", "PORT" })
+  self:addHints({ { key = "<gk>", desc = "Kill PF" } }, false, false, false)
+  self:setContent()
 end
 
 --- Execute a user command and handle the response

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -156,8 +156,7 @@ function M.PortForwards()
   self.extmarks = {}
 
   self.prettyData, self.extmarks = tables.pretty_print(self.data, { "PID", "TYPE", "RESOURCE", "PORT" })
-  self:addHints({ { key = "<gk>", desc = "Kill PF" } }, false, false, false)
-  self:setContent()
+  self:addHints({ { key = "<gk>", desc = "Kill PF" } }, false, false, false):setContent()
 end
 
 --- Execute a user command and handle the response

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -7,12 +7,13 @@ local M = {}
 
 function M.View()
   ResourceBuilder:new("namespace")
+    :displayFloatFit("k8s_namespace", "Namespace")
     :setCmd({ "{{BASE}}/api/v1/namespaces?pretty=false" }, "curl")
     :fetchAsync(function(self)
       self:decodeJson():process(definition.processRow, true):sort():prettyPrint(definition.getHeaders)
-
       vim.schedule(function()
-        self:displayFloat("k8s_namespace", "Namespace", "", true)
+        self:setContent()
+
         local win = vim.api.nvim_get_current_win()
         vim.api.nvim_win_set_cursor(win, { 2, 0 })
       end)
@@ -22,8 +23,7 @@ function M.changeNamespace(name)
   local function handle_output(_)
     vim.schedule(function()
       state.ns = name
-      local win = vim.api.nvim_get_current_win()
-      vim.api.nvim_win_close(win, true)
+      vim.api.nvim_buf_delete(0, { force = false })
       vim.api.nvim_input("gr")
     end)
   end

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -9,7 +9,7 @@ function M.View()
   ResourceBuilder:new("namespace")
     :setCmd({ "{{BASE}}/api/v1/namespaces?pretty=false" }, "curl")
     :fetchAsync(function(self)
-      self:decodeJson():process(definition.processRow):sort():prettyPrint(definition.getHeaders)
+      self:decodeJson():process(definition.processRow, true):sort():prettyPrint(definition.getHeaders)
 
       vim.schedule(function()
         self:displayFloat("k8s_namespace", "Namespace", "", true)

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -10,7 +10,7 @@ M.selection = {}
 
 function M.View(cancellationToken)
   local pfs = {}
-  root_definition.getPortForwards(pfs, true, "pods")
+  root_definition.getPFData(pfs, true, "pods")
   ResourceBuilder:new("pods")
     :setCmd({
       "{{BASE}}/api/v1/{{NAMESPACE}}pods?pretty=false",

--- a/lua/kubectl/views/services/init.lua
+++ b/lua/kubectl/views/services/init.lua
@@ -9,7 +9,7 @@ local M = {}
 
 function M.View(cancellationToken)
   local pfs = {}
-  root_definition.getPortForwards(pfs, true, "svc")
+  root_definition.getPFData(pfs, true, "svc")
   ResourceBuilder:new("services")
     :setCmd({ "{{BASE}}/api/v1/{{NAMESPACE}}services?pretty=false" }, "curl")
     :fetchAsync(function(self)


### PR DESCRIPTION
The hack with opening a buffer before loading content was causing issues when trying to do the fit to size buffer, since when we deleted or changed the rows in that floating buffer, there would be artifacts in the background.

This pr solves the hack to always preload the buffer and then setting the content instead or reopening it.
This pr also creates a new buffer type that is meant to adjust to the content.
This pr uses extmarks with virt_text for the divider otherwise it's difficult to determine what the max_width of regular content is.
