### PR TITLE
feat: prompt for text when no namespace available

### DIFF
--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -27,13 +27,27 @@ function M.View()
       end
       self:sort():prettyPrint(definition.getHeaders)
       vim.schedule(function()
-        self:setContent()
+        if #self.prettyData == 1 then
+          vim.api.nvim_set_current_line("Access to namespaces denied, please input your desired namespace")
+          vim.api.nvim_set_option_value("buftype", "prompt", { buf = self.buf_nr })
+          vim.fn.prompt_setcallback(self.buf_nr, function(input)
+            vim.api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
+            M.changeNamespace(input)
+          end)
 
-        local line_count = vim.api.nvim_buf_line_count(self.buf_nr)
+          vim.cmd("startinsert")
 
-        if line_count >= 2 then
-          local win = vim.api.nvim_get_current_win()
-          vim.api.nvim_win_set_cursor(win, { 2, 0 })
+          vim.keymap.set("n", "q", function()
+            vim.api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
+            vim.api.nvim_buf_delete(0, { force = true })
+          end, { buffer = self.buf_nr, silent = true })
+        else
+          self:setContent()
+          local line_count = vim.api.nvim_buf_line_count(self.buf_nr)
+          if line_count >= 2 then
+            local win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_cursor(win, { 2, 0 })
+          end
         end
       end)
     end)
@@ -42,7 +56,7 @@ function M.changeNamespace(name)
   local function handle_output(_)
     vim.schedule(function()
       state.ns = name
-      vim.api.nvim_buf_delete(0, { force = false })
+      vim.api.nvim_buf_delete(0, { force = true })
       vim.api.nvim_input("gr")
     end)
   end

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -40,7 +40,7 @@ function M.View()
 
           vim.keymap.set("n", "q", function()
             api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
-            api.nvim_buf_delete(0, { force = true })
+            api.nvim_buf_delete(self.buf_nr, { force = true })
           end, { buffer = self.buf_nr, silent = true })
         else
           self:setContent()

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -2,6 +2,7 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local commands = require("kubectl.actions.commands")
 local config = require("kubectl.config")
 local definition = require("kubectl.views.namespace.definition")
+local api = vim.api
 local state = require("kubectl.state")
 
 local M = {}
@@ -28,25 +29,25 @@ function M.View()
       self:sort():prettyPrint(definition.getHeaders)
       vim.schedule(function()
         if #self.prettyData == 1 then
-          vim.api.nvim_set_current_line("Access to namespaces denied, please input your desired namespace")
-          vim.api.nvim_set_option_value("buftype", "prompt", { buf = self.buf_nr })
+          api.nvim_set_current_line("Access to namespaces denied, please input your desired namespace")
+          api.nvim_set_option_value("buftype", "prompt", { buf = self.buf_nr })
           vim.fn.prompt_setcallback(self.buf_nr, function(input)
-            vim.api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
+            api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
             M.changeNamespace(input)
           end)
 
           vim.cmd("startinsert")
 
           vim.keymap.set("n", "q", function()
-            vim.api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
-            vim.api.nvim_buf_delete(0, { force = true })
+            api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
+            api.nvim_buf_delete(0, { force = true })
           end, { buffer = self.buf_nr, silent = true })
         else
           self:setContent()
-          local line_count = vim.api.nvim_buf_line_count(self.buf_nr)
+          local line_count = api.nvim_buf_line_count(self.buf_nr)
           if line_count >= 2 then
-            local win = vim.api.nvim_get_current_win()
-            vim.api.nvim_win_set_cursor(win, { 2, 0 })
+            local win = api.nvim_get_current_win()
+            api.nvim_win_set_cursor(win, { 2, 0 })
           end
         end
       end)
@@ -56,8 +57,8 @@ function M.changeNamespace(name)
   local function handle_output(_)
     vim.schedule(function()
       state.ns = name
-      vim.api.nvim_buf_delete(0, { force = true })
-      vim.api.nvim_input("gr")
+      api.nvim_buf_delete(0, { force = true })
+      api.nvim_input("gr")
     end)
   end
   if name == "All" then


### PR DESCRIPTION
To avoid have to use :Kubens <namespace> we can prompt for one instead.
This will only be when empty, in the future we might want to always have an input field
