### PR TITLE
fix: manipulate copy instead of original

### DIFF
--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -43,9 +43,9 @@ function M.setup(options)
       if #opts.fargs == 2 then
         local resource_type = opts.fargs[2]
         local viewsTable = require("kubectl.utils.viewsTable")
-        for viewKey, view in pairs(viewsTable) do
-          if vim.tbl_contains(view, resource_type) then
-            ok, x_view = pcall(require, "kubectl.views." .. viewKey)
+        for key, item in pairs(viewsTable) do
+          if vim.tbl_contains(item, resource_type) then
+            ok, x_view = pcall(require, "kubectl.views." .. key)
             if ok then
               break
             end

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -236,6 +236,10 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context, incl
   })
   local count = ""
   local filter = ""
+  local hints_copy = {}
+  for index, value in ipairs(hints) do
+    hints_copy[index] = value
+  end
   if self.prettyData then
     count = tostring(#self.prettyData - 1)
   elseif self.data then
@@ -245,7 +249,7 @@ function ResourceBuilder:addHints(hints, include_defaults, include_context, incl
     filter = state.filter
   end
   self.header.data, self.header.marks = tables.generateHeader(
-    hints,
+    hints_copy,
     include_defaults,
     include_context,
     { resource = string_util.capitalize(self.resource), count = count, filter = filter }

--- a/lua/kubectl/utils/url.lua
+++ b/lua/kubectl/utils/url.lua
@@ -53,11 +53,12 @@ end
 ---@param args string[]
 ---@return string[]
 function M.build(args)
+  local parsed_args = {}
   for i, arg in ipairs(args) do
-    args[i] = replacePlaceholders(arg)
+    parsed_args[i] = replacePlaceholders(arg)
   end
 
-  return args
+  return parsed_args
 end
 
 return M

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -6,11 +6,7 @@ local M = {
   resource = "pods",
   display_name = "Pods",
   ft = "k8s_pods",
-  url = {
-    "{{BASE}}/api/v1/{{NAMESPACE}}pods?pretty=false",
-    "-w",
-    "\n",
-  },
+  url = { "{{BASE}}/api/v1/{{NAMESPACE}}pods?pretty=false" },
   hints = {
     { key = "<gl>", desc = "logs" },
     { key = "<gd>", desc = "describe" },


### PR DESCRIPTION
#158 Introduced a bug since lua doesn't send tables by value and instead uses reference, that was fine when we didn't have the values stored in a variable (hardcoded parameters) but started getting corrupt when sent into a function that manipulates the input parameter.

Solved it by making copies of the arguments but the correct solution is to use immutable tables for readonly values.