### PR TITLE
fix/update-context-on-kubectx

### DIFF
--- a/lua/kubectl/completion.lua
+++ b/lua/kubectl/completion.lua
@@ -109,7 +109,8 @@ function M.change_context(cmd)
   vim.notify(results, vim.log.levels.INFO)
   kube.stop_kubectl_proxy()
   kube.startProxy(function()
-    vim.api.nvim_input("gr")
+    local state = require("kubectl.state")
+    state.setup()
   end)
 end
 


### PR DESCRIPTION
Fixes #170 
When changing the context, the context info at the top stays the same because it is only configured by `state.setup()`
so who not call it whenever changing context?