### PR TITLE
fix: sort when filtering

### DIFF
--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -220,7 +220,9 @@ function ResourceBuilder:prettyPrint(headersFunc)
   notifications.Add({
     "prettify table " .. "[" .. self.resource .. "]",
   })
-  self.prettyData, self.extmarks = tables.pretty_print(self.processedData, headersFunc(self.data))
+
+  self.prettyData, self.extmarks =
+    tables.pretty_print(self.processedData, headersFunc(self.data), state.sortby[self.resource])
   return self
 end
 
@@ -265,7 +267,6 @@ function ResourceBuilder:setContentRaw(cancellationToken)
 
   buffers.set_content(self.buf_nr, { content = self.data, marks = self.extmarks, header = self.header })
   notifications.Close()
-  self:postRender()
 
   return self
 end
@@ -278,7 +279,6 @@ function ResourceBuilder:setContent(cancellationToken)
 
   buffers.set_content(self.buf_nr, { content = self.prettyData, marks = self.extmarks, header = self.header })
   notifications.Close()
-  self:postRender()
 
   return self
 end
@@ -307,16 +307,6 @@ function ResourceBuilder:view(definition, cancellationToken, opts)
       builder:setContent(cancellationToken)
     end)
   end)
-end
-
---- Perform post-render actions
----@return ResourceBuilder
-function ResourceBuilder:postRender()
-  local marks = require("kubectl.utils.marks")
-  vim.schedule(function()
-    marks.set_sortby_header(self.resource)
-  end)
-  return self
 end
 
 return ResourceBuilder

--- a/lua/kubectl/utils/marks.lua
+++ b/lua/kubectl/utils/marks.lua
@@ -1,6 +1,5 @@
 local hl = require("kubectl.actions.highlight")
 local state = require("kubectl.state")
-local string_utils = require("kubectl.utils.string")
 
 local M = {}
 
@@ -18,36 +17,6 @@ function M.get_current_mark()
     return marks[1], current_word
   else
     return nil, current_word
-  end
-end
-
---- Set the sortby header based on the current state
---- @param resource string Resource for sort lookup
-function M.set_sortby_header(resource)
-  local sortby = state.sortby[resource]
-  if not sortby then
-    return
-  end
-
-  local function get_indicator(word, order)
-    return word .. (order == "asc" and " ▲" or " ▼")
-  end
-
-  if #sortby.mark == 0 and state.marks.header[1] then
-    local extmark = vim.api.nvim_buf_get_extmark_by_id(0, state.marks.ns_id, state.marks.header[1], { details = true })
-    if extmark and #extmark >= 3 then
-      local start_row, start_col, end_row, end_col = extmark[1], extmark[2], extmark[3].end_row, extmark[3].end_col
-      local lines = vim.api.nvim_buf_get_text(0, start_row, start_col, end_row, end_col, {})
-      local word = string_utils.trim(table.concat(lines, "\n"))
-
-      local indicator = get_indicator(word, sortby.order)
-      M.set_virtual_text_on_mark(0, state.marks.ns_id, { state.marks.header[1], start_row, start_col }, indicator)
-      state.sortby[resource].current_word = word
-      state.sortby_old.current_word = word
-    end
-  elseif #sortby.mark > 0 then
-    local indicator = get_indicator(sortby.current_word, sortby.order)
-    M.set_virtual_text_on_mark(0, state.marks.ns_id, { sortby.mark[1], sortby.mark[2], sortby.mark[3] }, indicator)
   end
 end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -184,7 +184,7 @@ end
 ---@param data table[]
 ---@param headers string[]
 ---@return table[], table[]
-function M.pretty_print(data, headers)
+function M.pretty_print(data, headers, sort_by)
   local columns = {}
   for k, v in ipairs(headers) do
     columns[k] = v:lower()
@@ -205,6 +205,16 @@ function M.pretty_print(data, headers)
     local value = header .. "  " .. string.rep(" ", column_width - #header + 1)
     table.insert(header_line, value)
 
+    if sort_by then
+      if header == sort_by.current_word then
+        table.insert(extmarks, {
+          row = 0,
+          start_col = #table.concat(header_line, "") - #value + #header,
+          virt_text = { { (sort_by.order == "asc" and " ▲" or " ▼"), hl.symbols.header } },
+          virt_text_pos = "overlay",
+        })
+      end
+    end
     M.add_mark(extmarks, 0, #table.concat(header_line, "") - #value, #table.concat(header_line, ""), hl.symbols.header)
   end
   table.insert(tbl, table.concat(header_line, ""))


### PR DESCRIPTION
Fixes #176 

When filtering or selecting namespace, the column widhts would be different since they are based on the content, that would make the sortby extmark needing to be updated.
This fix moves the sortby indicator to be created when we create the table it self, should now be dynamic to handle changing content.
Also, as a bonus we get a simpler implementation