### PR TITLE
Remove unnecessary nil-values in deployments table

### DIFF
--- a/lua/kubectl/views/deployments/definition.lua
+++ b/lua/kubectl/views/deployments/definition.lua
@@ -20,8 +20,8 @@ function M.processRow(rows)
         namespace = row.metadata.namespace,
         name = row.metadata.name,
         ready = M.getReady(row),
-        ["up-to-date"] = row.status.updatedReplicas,
-        available = row.status.availableReplicas,
+        ["up-to-date"] = row.status.updatedReplicas or "",
+        available = row.status.availableReplicas or "",
         age = time.since(row.metadata.creationTimestamp, true),
       }
 


### PR DESCRIPTION
Removes unnecessary 'nil' values from the deployment view. Changes from the following
![image](https://github.com/user-attachments/assets/ff7390a2-24cd-4fb8-bc2b-632fe39998cc)

To this:
![image](https://github.com/user-attachments/assets/f033aad7-1d22-40db-8cd0-e828a1160624)

