### PR TITLE
fix: reinitialize builder for fallback

### DIFF
--- a/lua/kubectl/views/fallback/init.lua
+++ b/lua/kubectl/views/fallback/init.lua
@@ -53,11 +53,7 @@ function M.View(cancellationToken, resource)
     definition.cmd = "curl"
   end
 
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)


### PR DESCRIPTION
Fallback view is an exception where builder needs to be recreated on enter/load