### PR TITLE
feat/completion-and-namespace

### DIFF
--- a/lua/kubectl/views/definition.lua
+++ b/lua/kubectl/views/definition.lua
@@ -125,7 +125,7 @@ function M.process_apis(api_url, group_name, group_version, group_resources, cac
       local resource_name = resource.name .. "." .. group_name
       local namespaced = resource.namespaced and "{{NAMESPACE}}" or ""
       local resource_url =
-        string.format("{{BASE}}/%s/%s/%s?pretty=false", api_url, group_version, namespaced, resource.name)
+        string.format("{{BASE}}/%s/%s/%s%s?pretty=false", api_url, group_version, namespaced, resource.name)
 
       cached_api_resources.values[resource_name] = {
         name = resource.name,

--- a/lua/kubectl/views/definition.lua
+++ b/lua/kubectl/views/definition.lua
@@ -118,12 +118,14 @@ function M.on_prompt_input(input)
   end
 end
 
-function M.process_apis(group_name, group_version, group_resources, cached_api_resources)
+function M.process_apis(api_url, group_name, group_version, group_resources, cached_api_resources)
   for _, resource in ipairs(group_resources.resources) do
     -- Skip if resource name contains '/status'
     if not string.find(resource.name, "/status") then
       local resource_name = resource.name .. "." .. group_name
-      local resource_url = string.format("{{BASE}}/apis/%s/{{NAMESPACE}}%s?pretty=false", group_version, resource.name)
+      local namespaced = resource.namespaced and "{{NAMESPACE}}" or ""
+      local resource_url =
+        string.format("{{BASE}}/%s/%s/%s?pretty=false", api_url, group_version, namespaced, resource.name)
 
       cached_api_resources.values[resource_name] = {
         name = resource.name,

--- a/lua/kubectl/views/definition.lua
+++ b/lua/kubectl/views/definition.lua
@@ -122,7 +122,7 @@ function M.process_apis(api_url, group_name, group_version, group_resources, cac
   for _, resource in ipairs(group_resources.resources) do
     -- Skip if resource name contains '/status'
     if not string.find(resource.name, "/status") then
-      local resource_name = resource.name .. "." .. group_name
+      local resource_name = group_name ~= "" and (resource.name .. "." .. group_name) or resource.name
       local namespaced = resource.namespaced and "{{NAMESPACE}}" or ""
       local resource_url =
         string.format("{{BASE}}/%s/%s/%s%s?pretty=false", api_url, group_version, namespaced, resource.name)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -16,6 +16,13 @@ if M.timestamp == nil or current_time - M.timestamp >= one_day_in_seconds then
   ResourceBuilder:new("api_resources"):setCmd({ "get", "--raw", "/apis" }, "kubectl"):fetchAsync(function(self)
     self:decodeJson()
 
+    -- process default api group
+    commands.shell_command_async("kubectl", { "get", "--raw", "/api/v1" }, function(group_data)
+      self.data = group_data
+      self:decodeJson()
+      definition.process_apis("api", "", "v1", self.data, M.cached_api_resources)
+    end)
+
     for _, group in ipairs(self.data.groups) do
       local group_name = group.name
       local group_version = group.preferredVersion.groupVersion
@@ -25,7 +32,7 @@ if M.timestamp == nil or current_time - M.timestamp >= one_day_in_seconds then
         commands.shell_command_async("kubectl", { "get", "--raw", "/apis/" .. group_version }, function(group_data)
           self.data = group_data
           self:decodeJson()
-          definition.process_apis(group_name, group_version, self.data, M.cached_api_resources)
+          definition.process_apis("apis", group_name, group_version, self.data, M.cached_api_resources)
         end)
       end
     end

--- a/lua/kubectl/views/pvc/definition.lua
+++ b/lua/kubectl/views/pvc/definition.lua
@@ -3,7 +3,7 @@ local M = {
   resource = "pvc",
   display_name = "pvc",
   ft = "k8s_pvc",
-  url = { "{{BASE}}/api/v1/persistentvolumeclaims?pretty=false" },
+  url = { "{{BASE}}/api/v1/{{NAMESPACE}}persistentvolumeclaims?pretty=false" },
   hints = {
     { key = "<gd>", desc = "describe", long_desc = "Describe selected pvc" },
   },

--- a/lua/kubectl/views/sa/definition.lua
+++ b/lua/kubectl/views/sa/definition.lua
@@ -3,7 +3,7 @@ local M = {
   resource = "sa",
   display_name = "sa",
   ft = "k8s_sa",
-  url = { "{{BASE}}/api/v1/serviceaccounts?pretty=false" },
+  url = { "{{BASE}}/api/v1/{{NAMESPACE}}serviceaccounts?pretty=false" },
   hints = {
     { key = "<gd>", desc = "describe", long_desc = "Describe selected serviceaccount" },
   },


### PR DESCRIPTION
1. there was no completion for resources under `/api/v1` since it's not returned in `/apis` so fetch it before
2. remove `{{NAMESPACE}}` for cluster-scoped resources
3. Add missing `{{NAMESPACE}}` to service accounts and pvc

regarding 2:
<img width="678" alt="image" src="https://github.com/user-attachments/assets/fc7d6e24-4f34-47ea-9d8e-ab13ec73cb09">
