### PR TITLE
fix: remove root mapping since it interferes with vim binding

### DIFF
--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -198,16 +198,6 @@ function M.register()
     end,
   })
 
-  vim.api.nvim_buf_set_keymap(0, "n", "0", "", {
-    noremap = true,
-    silent = true,
-    desc = "Root",
-    callback = function()
-      local view = require("kubectl.views.root")
-      view.View()
-    end,
-  })
-
   vim.api.nvim_buf_set_keymap(0, "n", "1", "", {
     noremap = true,
     silent = true,

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -60,7 +60,6 @@ function M.Hints(headers)
     { key = "<gs> ", desc = "Sort column" },
     { key = "<ge> ", desc = "Edit resource" },
     { key = "<gr> ", desc = "Refresh view" },
-    { key = "<0>  ", desc = "Root" },
     { key = "<1>  ", desc = "Deployments" },
     { key = "<2>  ", desc = "Pods " },
     { key = "<3>  ", desc = "Configmaps " },


### PR DESCRIPTION
As mentioned here: #202 this binding is overriding a default vim navigational binding.