### PR TITLE
fix: revert the exact filter method

### DIFF
--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -25,7 +25,7 @@ end
 ---@param tbl table
 ---@param str string
 ---@return boolean
-function M.is_in_table(tbl, str)
+function M.is_in_table(tbl, str, exact)
   if str == nil then
     return false
   end
@@ -36,10 +36,12 @@ function M.is_in_table(tbl, str)
       return false
     end
     if type(value) == "table" then
-      if M.is_in_table(value, str) then
+      if M.is_in_table(value, str, exact) then
         return true
       end
-    elseif tostring(value):lower():find(lowered_str, 1, true) then
+    elseif exact and tostring(value):lower() == lowered_str then
+      return true
+    elseif not exact and tostring(value):lower():find(lowered_str, 1, true) then
       return true
     end
   end

--- a/lua/kubectl/views/definition.lua
+++ b/lua/kubectl/views/definition.lua
@@ -98,7 +98,7 @@ function M.on_prompt_input(input)
   local parsed_input = string.lower(string_utils.trim(input))
   local supported_view = nil
   for k, v in pairs(viewsTable) do
-    if find.is_in_table(v, parsed_input) then
+    if find.is_in_table(v, parsed_input, true) then
       supported_view = k
     end
   end


### PR DESCRIPTION
In #199 we removed the exact matching for filtering, this caused problems when searching for aliases, for example trying to go to rolebinding would match for clusterrolebinding.
Returned the exact matching so that doesn't happen.

@mosheavni Will this revert affect the issue you had in #199? I'm thinking the issue you had was for filtering in content and not when filtering aliases, correct?