### PR TITLE
decrease refresh timer, don't refresh view when state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Processes kubectl outputs to enable vim-like navigation in a buffer for your clu
 </details>
 <details>
   <summary>Sort by headers</summary>
-    <sub>By moving the cursor to a header word and pressing <code>s</code></sub>
+    <sub>By moving the cursor to a column and pressing <code>s</code></sub>
   <img src="https://github.com/Ramilito/kubectl.nvim/assets/17252601/9f96e943-eda4-458e-a4ba-cf23e0417963" width="700px">
 </details>
 <details>

--- a/lua/kubectl/config.lua
+++ b/lua/kubectl/config.lua
@@ -12,7 +12,7 @@ local M = {}
 local defaults = {
   auto_refresh = {
     enabled = true,
-    interval = 3000, -- milliseconds
+    interval = 300, -- milliseconds
   },
   diff = {
     bin = "kubediff",

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -49,10 +49,6 @@ function M.setup()
     end
     M.ns = config.options.namespace
     M.filter = ""
-
-    vim.schedule(function()
-      commands.restore_session()
-    end)
   end)
 end
 


### PR DESCRIPTION
The state refresh was not needed now that we redraw at a faster pace.
Also solves an issue where opening a floating buffer too fast would redraw the bg buffer in the floating buffer.

Also lowering refresh rate since we now use low cost redraws.