### PR TITLE
fix/fallback-before-cached-resources

### DIFF
--- a/lua/kubectl/views/fallback/init.lua
+++ b/lua/kubectl/views/fallback/init.lua
@@ -53,7 +53,7 @@ function M.View(cancellationToken, resource)
     definition.cmd = "curl"
   end
 
-  M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
+  M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken, { cmd = definition.cmd })
 end
 
 function M.Draw(cancellationToken)


### PR DESCRIPTION
when opening the plugin, and then going very fast to some resource that don't have a view (fallback), then the cmd is something along the lines of
```
curl ... get externalsecrets -A
```

and we get an error curl is missing flags or something like that.
this ensures we still see something before we load the cached-resources