### PR TITLE
feat/namespace-completion-All

### DIFF
--- a/lua/kubectl/utils/completion.lua
+++ b/lua/kubectl/utils/completion.lua
@@ -25,7 +25,7 @@ function M.with_completion(buf, data, callback)
       local filtered_suggestions = {}
 
       for _, suggestion in pairs(data) do
-        if suggestion.name:sub(1, #original_input) == original_input then
+        if suggestion.name:lower():sub(1, #original_input) == original_input then
           table.insert(filtered_suggestions, suggestion.name)
         end
       end

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -19,7 +19,7 @@ function M.View()
       self.buf_nr = buf
       self:process(definition.processRow):prettyPrint(definition.getHeaders):setContent()
 
-      local list = {}
+      local list = { { name = "All" } }
       for _, value in ipairs(self.processedData) do
         if value.name.value then
           table.insert(list, { name = value.name.value })


### PR DESCRIPTION
When completing namespaces, also complete "All"
lowercase is because kubernetes resources are case-insensitive, based on https://tools.ietf.org/html/rfc952