### PR TITLE
feat/fallback-for-vim-nil

### DIFF
--- a/lua/kubectl/views/fallback/definition.lua
+++ b/lua/kubectl/views/fallback/definition.lua
@@ -62,7 +62,8 @@ function M.processRow(rows)
 
   -- process curl table json
   if rows.rows then
-    for _, row in pairs(rows.rows) do
+    local rows_table = rows.rows ~= vim.NIL and rows.rows or {}
+    for _, row in pairs(rows_table) do
       local resource_vals = row.cells
       local resource = {}
       local namespace = row.object.metadata.namespace
@@ -106,7 +107,7 @@ function M.getHeaders(rows)
   local headers
   if rows.columnDefinitions then
     headers = {}
-    local firstRow = rows.rows[1]
+    local firstRow = rows.rows ~= vim.NIL and rows.rows[1]
     if firstRow and firstRow.object and firstRow.object.metadata and firstRow.object.metadata.namespace then
       table.insert(headers, "NAMESPACE")
     end


### PR DESCRIPTION
For some reason, the fallback view for `LimitRanges` is returning `vim.NIL` on `rows.rows` if there are no objects.

This makes sure we won't fall on vim.NIL in fallback again.