### PR TITLE
feat/capitalize-events

### DIFF
--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -106,7 +106,7 @@ function M.ColorStatus(status)
   if type(status) ~= "string" then
     return ""
   end
-  local capitalized = string_util.capitalize(status)
+  local capitalized = string_utils.capitalize(status)
   if errorStatuses[capitalized] then
     return hl.symbols.error
   elseif warningStatuses[capitalized] then

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -109,9 +109,8 @@ function M.ColorStatus(status)
     return hl.symbols.warning
   elseif successStatuses[capitalized] then
     return hl.symbols.success
-  else
-    return ""
   end
+  return ""
 end
 
 return M

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -99,6 +99,9 @@ function M.ColorStatus(status)
     True = true,
   }
 
+  if type(status) ~= "string" then
+    return ""
+  end
   local capitalized = status:gsub("^%l", string.upper)
   if errorStatuses[capitalized] then
     return hl.symbols.error

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -73,6 +73,7 @@ function M.ColorStatus(status)
     Available = true,
     Released = true,
     ScalingReplicaSet = true,
+    EvictedByVPA = true,
   }
 
   local successStatuses = {
@@ -97,6 +98,8 @@ function M.ColorStatus(status)
     -- Custom statuses
     Active = true,
     True = true,
+    SuccessfullyReconciled = true,
+    UpdatedLoadBalancer = true,
   }
 
   if type(status) ~= "string" then

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -88,7 +88,6 @@ function M.ColorStatus(status)
     Normal = true,
     VolumeResizeSuccessful = true,
     FileSystemResizeSuccessful = true,
-    SecretSynced = true,
     Ready = true,
     Scheduled = true,
     SuccessfulCreate = true,

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -30,6 +30,7 @@ function M.ColorStatus(status)
     FailedMountOnFilesystemMismatch = true,
     InvalidDiskCapacity = true,
     FreeDiskSpaceFailed = true,
+    SecretSyncedError = true,
     Unhealthy = true,
     FailedSync = true,
     FailedValidation = true,
@@ -86,6 +87,7 @@ function M.ColorStatus(status)
     Normal = true,
     VolumeResizeSuccessful = true,
     FileSystemResizeSuccessful = true,
+    SecretSynced = true,
     Ready = true,
     Scheduled = true,
     SuccessfulCreate = true,
@@ -97,11 +99,12 @@ function M.ColorStatus(status)
     True = true,
   }
 
-  if errorStatuses[status] then
+  local capitalized = status:gsub("^%l", string.upper)
+  if errorStatuses[capitalized] then
     return hl.symbols.error
-  elseif warningStatuses[status] then
+  elseif warningStatuses[capitalized] then
     return hl.symbols.warning
-  elseif successStatuses[status] then
+  elseif successStatuses[capitalized] then
     return hl.symbols.success
   else
     return ""

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -97,6 +97,7 @@ function M.ColorStatus(status)
     -- Custom statuses
     Active = true,
     True = true,
+    SecretSynced = true,
     SuccessfullyReconciled = true,
     UpdatedLoadBalancer = true,
   }

--- a/lua/kubectl/utils/events.lua
+++ b/lua/kubectl/utils/events.lua
@@ -1,4 +1,5 @@
 local hl = require("kubectl.actions.highlight")
+local string_utils = require("kubectl.utils.string")
 local M = {}
 
 --- Color a status based on its severity
@@ -105,7 +106,7 @@ function M.ColorStatus(status)
   if type(status) ~= "string" then
     return ""
   end
-  local capitalized = status:gsub("^%l", string.upper)
+  local capitalized = string_util.capitalize(status)
   if errorStatuses[capitalized] then
     return hl.symbols.error
   elseif warningStatuses[capitalized] then


### PR DESCRIPTION
I have custom resources: kibanas and elasticsearches
they both have `green`, `yellow` or `red` on their status.
not capitalized.
I figured we better capitalize anyway to get the colors right.
before:
<img width="703" alt="image" src="https://github.com/user-attachments/assets/120fece8-bf06-460b-a60b-b24df2f8c936">

after:
<img width="945" alt="image" src="https://github.com/user-attachments/assets/96559244-59b7-429b-aa26-c7985fab9da8">
