### PR TITLE
chore/print-0-deployments

### DIFF
--- a/lua/kubectl/views/deployments/definition.lua
+++ b/lua/kubectl/views/deployments/definition.lua
@@ -25,8 +25,8 @@ function M.processRow(rows)
         namespace = row.metadata.namespace,
         name = row.metadata.name,
         ready = M.getReady(row),
-        ["up-to-date"] = row.status.updatedReplicas or "0",
-        available = row.status.availableReplicas or "0",
+        ["up-to-date"] = row.status.updatedReplicas or 0,
+        available = row.status.availableReplicas or 0,
         age = time.since(row.metadata.creationTimestamp, true),
       }
 

--- a/lua/kubectl/views/deployments/definition.lua
+++ b/lua/kubectl/views/deployments/definition.lua
@@ -25,8 +25,8 @@ function M.processRow(rows)
         namespace = row.metadata.namespace,
         name = row.metadata.name,
         ready = M.getReady(row),
-        ["up-to-date"] = row.status.updatedReplicas or "",
-        available = row.status.availableReplicas or "",
+        ["up-to-date"] = row.status.updatedReplicas or "0",
+        available = row.status.availableReplicas or "0",
         age = time.since(row.metadata.creationTimestamp, true),
       }
 


### PR DESCRIPTION
kubectl get deployment outputs `0` when there are no available or up-to-date replicas.
<img width="612" alt="image" src="https://github.com/user-attachments/assets/dd142c65-072e-4e42-bf16-5ee7b51345e9">

