### PR TITLE
feat/namespace-view-or-switch

### DIFF
--- a/lua/kubectl/completion.lua
+++ b/lua/kubectl/completion.lua
@@ -91,16 +91,7 @@ function M.list_namespace()
       table.insert(ns, namespace)
     end
   end
-
   return ns
-end
-
---- Change namespace
---- @param cmd string
-function M.change_namespace(cmd)
-  local results = commands.shell_command("kubectl", { "config", "set-context", "--current", "--namespace=" .. cmd })
-
-  vim.notify(results, vim.log.levels.INFO)
 end
 
 --- Change context and restart proxy

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -80,7 +80,12 @@ function M.setup(options)
   })
 
   vim.api.nvim_create_user_command("Kubens", function(opts)
-    completion.change_namespace(opts.fargs[1])
+    local namespace_view = require("kubectl.views.namespace")
+    if #opts.fargs == 0 then
+      namespace_view.View()
+    else
+      namespace_view.changeNamespace(opts.fargs[1])
+    end
   end, {
     nargs = "*",
     complete = completion.list_namespace,


### PR DESCRIPTION
If you type: `:Kubens` without args, open the namespace view
If you type: `:Kubens some-ns`, change to it

remove the duplicated function to change NS since we already have it in the namespace view

future thoughts:
do the same for `:Kubectx`