### PR TITLE
fix/no-containers-on-filter

### DIFF
--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -303,10 +303,10 @@ function ResourceBuilder:view_float(definition, opts)
       vim.schedule(function()
         if definition.processRow then
           builder
-            :process(definition.processRow)
+            :process(definition.processRow, true)
             :sort()
             :prettyPrint(definition.getHeaders)
-            :addHints(definition.hints, true, true, true)
+            :addHints(definition.hints, true, false, false)
             :setContent()
         else
           builder:splitData():setContentRaw()


### PR DESCRIPTION
there's an issue when I hit <kbd>\<enter></kbd> on a pod when there is a filter going on, we won't see any container.

I checked who is using `ResourceBuilder:view_float` and it's only pods and containers.
in both cases we want to pass `no_filter` as true to `:process()`
and `include_context` and `include_filter` both as `false` to `:addHints()`