### PR TITLE
fix: use correct resource names

### DIFF
--- a/lua/kubectl/views/pv/definition.lua
+++ b/lua/kubectl/views/pv/definition.lua
@@ -1,7 +1,7 @@
 local events = require("kubectl.utils.events")
 local time = require("kubectl.utils.time")
 local M = {
-  resource = "PersistentVolumes",
+  resource = "pv",
   display_name = "PersistentVolumes",
   ft = "k8s_pv",
   url = { "{{BASE}}/api/v1/persistentvolumes?pretty=false" },

--- a/lua/kubectl/views/pvc/definition.lua
+++ b/lua/kubectl/views/pvc/definition.lua
@@ -1,7 +1,7 @@
 local events = require("kubectl.utils.events")
 local time = require("kubectl.utils.time")
 local M = {
-  resource = "persistentvolumeclaims",
+  resource = "pvc",
   display_name = "PersistentVolumeClaims",
   ft = "k8s_pvc",
   url = { "{{BASE}}/api/v1/{{NAMESPACE}}persistentvolumeclaims?pretty=false" },


### PR DESCRIPTION
The resource names need to match the folder they live in if not using the lookup table.
A previous commit made the display_name be used for the divider row so it should be disconnected now 