### PR TITLE
feat: reuse float window

### DIFF
--- a/ftplugin/k8s_pod_logs.lua
+++ b/ftplugin/k8s_pod_logs.lua
@@ -38,7 +38,6 @@ local function set_keymaps(bufnr)
       else
         pod_view.show_timestamps = "true"
       end
-      vim.cmd.close()
       pod_view.Logs()
     end,
   })
@@ -53,7 +52,6 @@ local function set_keymaps(bufnr)
       else
         pod_view.show_log_prefix = "true"
       end
-      vim.cmd.close()
       pod_view.Logs()
     end,
   })

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -115,7 +115,8 @@ function M.aliases_buffer(filetype, callback, opts)
 
   vim.cmd("startinsert")
 
-  layout.set_buf_options(buf, win, filetype, "", bufname)
+  layout.set_buf_options(buf, filetype, "", bufname)
+  layout.set_win_options(win)
   return buf
 end
 
@@ -152,7 +153,8 @@ function M.filter_buffer(filetype, callback, opts)
 
   vim.cmd("startinsert")
 
-  layout.set_buf_options(buf, win, filetype, "", bufname)
+  layout.set_buf_options(buf, filetype, "", bufname)
+  layout.set_win_options(win)
   return buf
 end
 
@@ -189,7 +191,9 @@ function M.confirmation_buffer(prompt, filetype, onConfirm, opts)
   })
   vim.keymap.set("n", "q", vim.cmd.close, { buffer = buf, silent = true })
 
-  layout.set_buf_options(buf, win, filetype, opts.syntax or filetype, bufname)
+  layout.set_buf_options(buf, filetype, opts.syntax or filetype, bufname)
+  layout.set_win_options(win)
+
   M.apply_marks(buf, opts.marks, nil)
 
   local win_config = layout.win_size_fit_content(buf, 2)
@@ -235,7 +239,8 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
     vim.cmd("startinsert")
   end
 
-  layout.set_buf_options(buf, win, filetype, "", bufname)
+  layout.set_buf_options(buf, filetype, "", bufname)
+  layout.set_win_options(win)
   layout.win_size_fit_content(buf, 2)
   return buf
 end
@@ -254,8 +259,9 @@ end
 --- @param filetype string: The filetype of the buffer.
 --- @param title string: The buffer title
 --- @param syntax string?: The buffer title
---- @return integer: The buffer number.
-function M.floating_buffer(filetype, title, syntax)
+--- @param win integer?: The buffer title
+--- @return integer, integer: The buffer and win number.
+function M.floating_buffer(filetype, title, syntax, win)
   local bufname = title or "kubectl_float"
   local buf = get_buffer_by_name(bufname)
 
@@ -263,15 +269,19 @@ function M.floating_buffer(filetype, title, syntax)
     buf = create_buffer(bufname)
   end
 
-  local win = layout.float_layout(buf, filetype, title or "")
+  if not win then
+    win = layout.float_layout(buf, filetype, title or "")
+    layout.set_win_options(win)
+  end
+
+  layout.set_buf_options(buf, filetype, syntax or filetype, bufname)
+
   vim.keymap.set("n", "q", function()
     vim.cmd.close()
   end, { buffer = buf, silent = true })
 
-  layout.set_buf_options(buf, win, filetype, syntax or filetype, bufname)
-
   M.set_content(buf, { content = { "Loading..." } })
-  return buf
+  return buf, win
 end
 
 --- Creates or updates a buffer.
@@ -284,7 +294,8 @@ function M.buffer(filetype, title)
 
   if not buf then
     buf = create_buffer(bufname)
-    layout.set_buf_options(buf, win, filetype, filetype, bufname)
+    layout.set_buf_options(buf, filetype, filetype, bufname)
+    layout.set_win_options(win)
   end
 
   api.nvim_set_current_buf(buf)

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -269,7 +269,8 @@ function M.floating_buffer(filetype, title, syntax, win)
     buf = create_buffer(bufname)
   end
 
-  if not win then
+  local _, is_valid = pcall(vim.api.nvim_win_is_valid, win)
+  if not win or not is_valid then
     win = layout.float_layout(buf, filetype, title or "")
     layout.set_win_options(win)
   end

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -3,18 +3,22 @@ local M = {}
 local api = vim.api
 
 --- Set buffer options.
---- @param buf integer: The buffer number.
 --- @param win integer: The window number.
+function M.set_win_options(win)
+  api.nvim_set_option_value("cursorline", true, { win = win })
+  api.nvim_set_option_value("wrap", false, { win = win })
+end
+
+--- Set buffer options.
+--- @param buf integer: The buffer number.
 --- @param filetype string: The filetype for the buffer.
 --- @param syntax string: The syntax for the buffer.
 --- @param bufname string: The name of the buffer.
-function M.set_buf_options(buf, win, filetype, syntax, bufname)
+function M.set_buf_options(buf, filetype, syntax, bufname)
   api.nvim_set_option_value("filetype", filetype, { buf = buf })
   api.nvim_set_option_value("syntax", syntax, { buf = buf })
   api.nvim_set_option_value("bufhidden", "hide", { scope = "local" })
-  api.nvim_set_option_value("cursorline", true, { win = win })
   api.nvim_set_option_value("modified", false, { buf = buf })
-  api.nvim_set_option_value("wrap", false, { win = win })
   api.nvim_buf_set_var(buf, "buf_name", bufname)
 
   -- TODO: How do we handle long text?

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -1,6 +1,7 @@
 local informer = require("kubectl.actions.informer")
 local ns_view = require("kubectl.views.namespace")
 local state = require("kubectl.state")
+local view = require("kubectl.views")
 
 local M = {
   is_open = false,
@@ -13,6 +14,7 @@ function M.open()
 
   hl.setup()
   kube.start_kubectl_proxy(function()
+    view.LoadFallbackData()
     state.setup()
   end)
 end

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -61,7 +61,6 @@ function M.setup(options)
   })
 
   vim.api.nvim_create_user_command("Kubectl", function(opts)
-    local view = require("kubectl.views")
     local action = opts.fargs[1]
     if action == "get" then
       if #opts.fargs == 2 then

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -2,7 +2,6 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local string_utils = require("kubectl.utils.string")
-local views = require("kubectl.views")
 local M = {}
 
 local function is_plug_mapped(plug_target, mode)
@@ -47,7 +46,8 @@ function M.register()
     silent = true,
     desc = "View Port Forwards",
     callback = function()
-      views.PortForwards()
+      local view = require("kubectl.views")
+      view.PortForwards()
     end,
   })
 

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -152,6 +152,7 @@ function M.register()
     silent = true,
     desc = "Edit resource",
     callback = function()
+      local state = require("kubectl.state")
       local win_config = vim.api.nvim_win_get_config(0)
       if win_config.relative ~= "" then
         return
@@ -165,7 +166,7 @@ function M.register()
       end
 
       -- Get resource details and construct the kubectl command
-      local resource = view.builder.resource
+      local resource = state.instance.resource
       local name, ns = view.getCurrentSelection()
 
       if not name then

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -299,7 +299,8 @@ function ResourceBuilder:view_float(definition, opts)
   opts = opts or {}
   opts.cmd = opts.cmd or "curl"
 
-  if not self.resource then
+  self = state.instance_float
+  if not self or not self.resource or self.resource ~= definition.resource then
     self = ResourceBuilder:new(definition.resource)
   end
 
@@ -328,6 +329,7 @@ function ResourceBuilder:view_float(definition, opts)
       end)
     end)
 
+  state.instance_float = self
   return self
 end
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -58,7 +58,7 @@ function ResourceBuilder:displayFloat(filetype, title, syntax)
   notifications.Add({
     "display data " .. "[" .. self.resource .. "]",
   })
-  self.buf_nr = buffers.floating_buffer(filetype, title, syntax)
+  self.buf_nr, self.win_nr = buffers.floating_buffer(filetype, title, syntax, self.win_nr)
 
   return self
 end

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -297,9 +297,16 @@ end
 
 function ResourceBuilder:view_float(definition, opts)
   opts = opts or {}
-  ResourceBuilder:new(definition.resource)
+  opts.cmd = opts.cmd or "curl"
+
+  if not self.resource then
+    self = ResourceBuilder:new(definition.resource)
+  end
+
+  self.definition = definition
+  self
     :displayFloat(definition.ft, definition.resource, definition.syntax)
-    :setCmd(definition.url, opts.cmd or "curl", opts.contentType)
+    :setCmd(definition.url, opts.cmd, opts.contentType)
     :fetchAsync(function(builder)
       builder:decodeJson()
 

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -338,6 +338,11 @@ function ResourceBuilder:view(definition, cancellationToken, opts)
   opts.cmd = opts.cmd or "curl"
   self.definition = definition
 
+  self = state.instance
+  if not self or not self.resource or self.resource ~= definition.resource then
+    self = ResourceBuilder:new(definition.resource)
+  end
+
   self
     :display(definition.ft, definition.resource, cancellationToken)
     :setCmd(definition.url, opts.cmd)
@@ -353,6 +358,7 @@ function ResourceBuilder:view(definition, cancellationToken, opts)
       end)
     end)
 
+  state.instance = self
   return self
 end
 
@@ -367,6 +373,7 @@ function ResourceBuilder:draw(definition, cancellationToken)
     self:setContent(cancellationToken)
   end)
 
+  state.instance = self
   return self
 end
 

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -23,6 +23,10 @@ M.sortby = {}
 M.sortby_old = { current_word = "" }
 ---@type table
 M.session = { contexts = {}, filter_history = {} }
+---@type table
+M.instance = nil
+---@type table
+M.instance_float = nil
 
 --- Decode a JSON string
 --- @param string string The JSON string to decode

--- a/lua/kubectl/views/clusterrolebinding/init.lua
+++ b/lua/kubectl/views/clusterrolebinding/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.clusterrolebinding.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Edit(name)

--- a/lua/kubectl/views/configmaps/init.lua
+++ b/lua/kubectl/views/configmaps/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.configmaps.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 --- Edit a configmap

--- a/lua/kubectl/views/crds/init.lua
+++ b/lua/kubectl/views/crds/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.crds.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 --- Edit a configmap

--- a/lua/kubectl/views/cronjobs/init.lua
+++ b/lua/kubectl/views/cronjobs/init.lua
@@ -2,22 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.cronjobs.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = {
-  builder = nil,
-}
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken, { cmd = "curl" })
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Desc(name, ns)

--- a/lua/kubectl/views/daemonsets/init.lua
+++ b/lua/kubectl/views/daemonsets/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.daemonsets.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Desc(name, ns)

--- a/lua/kubectl/views/deployments/init.lua
+++ b/lua/kubectl/views/deployments/init.lua
@@ -2,22 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.deployments.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = {
-  builder = nil,
-}
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Desc(name, ns)

--- a/lua/kubectl/views/events/init.lua
+++ b/lua/kubectl/views/events/init.lua
@@ -1,20 +1,17 @@
 local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local definition = require("kubectl.views.events.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.ShowMessage(event)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -14,36 +14,38 @@ M.cached_api_resources = { values = {}, shortNames = {}, timestamp = nil }
 local one_day_in_seconds = 24 * 60 * 60
 local current_time = os.time()
 
-if M.timestamp == nil or current_time - M.timestamp >= one_day_in_seconds then
-  ResourceBuilder:new("api_resources"):setCmd({ "get", "--raw", "/apis" }, "kubectl"):fetchAsync(function(self)
-    self:decodeJson()
-
-    -- process default api group
-    commands.shell_command_async("kubectl", { "get", "--raw", "/api/v1" }, function(group_data)
-      self.data = group_data
+M.LoadFallbackData = function()
+  if M.timestamp == nil or current_time - M.timestamp >= one_day_in_seconds then
+    ResourceBuilder:new("api_resources"):setCmd({ "get", "--raw", "/apis" }, "kubectl"):fetchAsync(function(self)
       self:decodeJson()
-      definition.process_apis("api", "", "v1", self.data, M.cached_api_resources)
+
+      -- process default api group
+      commands.shell_command_async("kubectl", { "get", "--raw", "/api/v1" }, function(group_data)
+        self.data = group_data
+        self:decodeJson()
+        definition.process_apis("api", "", "v1", self.data, M.cached_api_resources)
+      end)
+
+      if self.data.groups == nil then
+        return
+      end
+      for _, group in ipairs(self.data.groups) do
+        local group_name = group.name
+        local group_version = group.preferredVersion.groupVersion
+
+        -- Skip if name contains 'metrics.k8s.io'
+        if not string.find(group_name, "metrics.k8s.io") then
+          commands.shell_command_async("kubectl", { "get", "--raw", "/apis/" .. group_version }, function(group_data)
+            self.data = group_data
+            self:decodeJson()
+            definition.process_apis("apis", group_name, group_version, self.data, M.cached_api_resources)
+          end)
+        end
+      end
     end)
 
-    if self.data.groups == nil then
-      return
-    end
-    for _, group in ipairs(self.data.groups) do
-      local group_name = group.name
-      local group_version = group.preferredVersion.groupVersion
-
-      -- Skip if name contains 'metrics.k8s.io'
-      if not string.find(group_name, "metrics.k8s.io") then
-        commands.shell_command_async("kubectl", { "get", "--raw", "/apis/" .. group_version }, function(group_data)
-          self.data = group_data
-          self:decodeJson()
-          definition.process_apis("apis", group_name, group_version, self.data, M.cached_api_resources)
-        end)
-      end
-    end
-  end)
-
-  M.timestamp = os.time()
+    M.timestamp = os.time()
+  end
 end
 
 --- Generate hints and display them in a floating buffer

--- a/lua/kubectl/views/jobs/init.lua
+++ b/lua/kubectl/views/jobs/init.lua
@@ -2,27 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.jobs.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = {
-  builder = nil,
-}
+local M = {}
 
 function M.View(cancellationToken)
-  definition.owner = {}
-  definition.display_name = "Jobs"
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken, { cmd = "curl" })
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  if definition.owner.name then
-    definition.display_name = "Jobs" .. "(" .. definition.owner.ns .. "/" .. definition.owner.name .. ")"
-  end
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Desc(name, ns)

--- a/lua/kubectl/views/jobs/init.lua
+++ b/lua/kubectl/views/jobs/init.lua
@@ -8,10 +8,15 @@ local tables = require("kubectl.utils.tables")
 local M = {}
 
 function M.View(cancellationToken)
+  definition.owner = {}
+  definition.display_name = "Jobs"
   ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
+  if definition.owner.name then
+    definition.display_name = "Jobs" .. "(" .. definition.owner.ns .. "/" .. definition.owner.name .. ")"
+  end
   state.instance:draw(definition, cancellationToken)
 end
 

--- a/lua/kubectl/views/nodes/init.lua
+++ b/lua/kubectl/views/nodes/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.nodes.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Drain(node)

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -149,7 +149,7 @@ end
 
 local function getPodStatus(row)
   local status = row.status.phase
-  local ok = false
+  local ok
 
   if row.status.reason ~= nil then
     if row.deletionTimestamp ~= nil and row.status.reason == "NodeLost" then

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -7,6 +7,8 @@ local tables = require("kubectl.utils.tables")
 
 local M = {
   builder = nil,
+  desc_builder = nil,
+  log_builder = nil,
   selection = {},
   pfs = {},
   tail_handle = nil,
@@ -90,7 +92,7 @@ function M.selectPod(pod, ns)
 end
 
 function M.Logs()
-  ResourceBuilder:view_float({
+  local def = {
     resource = "logs",
     ft = "k8s_pod_logs",
     url = {
@@ -109,7 +111,13 @@ function M.Logs()
       { key = "<Plug>(kubectl.prefix)", desc = "Prefix" },
       { key = "<Plug>(kubectl.timestamps)", desc = "Timestamps" },
     },
-  }, { cmd = "kubectl" })
+  }
+
+  if M.log_builder then
+    M.log_builder:view_float(def, { cmd = "kubectl" })
+  else
+    M.log_builder = ResourceBuilder:view_float(def, { cmd = "kubectl" })
+  end
 end
 
 function M.Edit(name, ns)
@@ -118,12 +126,14 @@ function M.Edit(name, ns)
 end
 
 function M.Desc(name, ns)
-  ResourceBuilder:view_float({
+  local def = {
     resource = "desc",
     ft = "k8s_pod_desc",
     url = { "describe", "pod", name, "-n", ns },
     syntax = "yaml",
-  }, { cmd = "kubectl" })
+  }
+
+  M.desc_builder = ResourceBuilder:view_float(def, { cmd = "kubectl" })
 end
 
 --- Get current seletion for view

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -3,10 +3,10 @@ local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.pods.definition")
 local root_definition = require("kubectl.views.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
 local M = {
-  builder = nil,
   selection = {},
   pfs = {},
   tail_handle = nil,
@@ -18,16 +18,12 @@ local M = {
 function M.View(cancellationToken)
   M.pfs = {}
   root_definition.getPFData(M.pfs, true, "pods")
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
-  root_definition.setPortForwards(M.builder.extmarks, M.builder.prettyData, M.pfs)
+  state.instance:draw(definition, cancellationToken)
+  root_definition.setPortForwards(state.instance.extmarks, state.instance.prettyData, M.pfs)
 end
 
 function M.TailLogs(pod, ns, container)

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -7,8 +7,6 @@ local tables = require("kubectl.utils.tables")
 
 local M = {
   builder = nil,
-  desc_builder = nil,
-  log_builder = nil,
   selection = {},
   pfs = {},
   tail_handle = nil,
@@ -113,11 +111,7 @@ function M.Logs()
     },
   }
 
-  if M.log_builder then
-    M.log_builder:view_float(def, { cmd = "kubectl" })
-  else
-    M.log_builder = ResourceBuilder:view_float(def, { cmd = "kubectl" })
-  end
+  ResourceBuilder:view_float(def, { cmd = "kubectl" })
 end
 
 function M.Edit(name, ns)
@@ -133,7 +127,7 @@ function M.Desc(name, ns)
     syntax = "yaml",
   }
 
-  M.desc_builder = ResourceBuilder:view_float(def, { cmd = "kubectl" })
+  ResourceBuilder:view_float(def, { cmd = "kubectl" })
 end
 
 --- Get current seletion for view

--- a/lua/kubectl/views/pv/init.lua
+++ b/lua/kubectl/views/pv/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.pv.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Edit(name)

--- a/lua/kubectl/views/pvc/init.lua
+++ b/lua/kubectl/views/pvc/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.pvc.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Edit(name, ns)

--- a/lua/kubectl/views/sa/init.lua
+++ b/lua/kubectl/views/sa/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.sa.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Edit(name, ns)

--- a/lua/kubectl/views/secrets/init.lua
+++ b/lua/kubectl/views/secrets/init.lua
@@ -2,20 +2,17 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.secrets.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
+  state.instance:draw(definition, cancellationToken)
 end
 
 function M.Edit(name, ns)

--- a/lua/kubectl/views/services/init.lua
+++ b/lua/kubectl/views/services/init.lua
@@ -3,6 +3,7 @@ local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.services.definition")
 local root_definition = require("kubectl.views.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
 local M = { builder = nil, pfs = {} }
@@ -10,16 +11,12 @@ local M = { builder = nil, pfs = {} }
 function M.View(cancellationToken)
   M.pfs = {}
   root_definition.getPFData(M.pfs, true, "svc")
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken)
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken)
-  end
+  ResourceBuilder:view(definition, cancellationToken)
 end
 
 function M.Draw(cancellationToken)
-  M.builder = M.builder:draw(definition, cancellationToken)
-  root_definition.setPortForwards(M.builder.extmarks, M.builder.prettyData, M.pfs)
+  state.instance:draw(definition, cancellationToken)
+  root_definition.setPortForwards(state.instance.extmarks, state.instance.prettyData, M.pfs)
 end
 
 function M.Edit(name, ns)

--- a/lua/kubectl/views/top/definition.lua
+++ b/lua/kubectl/views/top/definition.lua
@@ -18,7 +18,7 @@ local M = {
 local hl = require("kubectl.actions.highlight")
 
 local function getHl(percent)
-  local symbol = ""
+  local symbol
   if percent < 80 then
     symbol = hl.symbols.note
   elseif percent < 90 then

--- a/lua/kubectl/views/top/init.lua
+++ b/lua/kubectl/views/top/init.lua
@@ -2,16 +2,13 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local definition = require("kubectl.views.top.definition")
 local tables = require("kubectl.utils.tables")
 
-local M = { builder = nil }
+local M = {}
 
 function M.View(cancellationToken)
   definition.url = definition.urls[definition.res_type]
   definition.display_name = "top " .. definition.res_type
-  if M.builder then
-    M.builder = M.builder:view(definition, cancellationToken, { informer = false })
-  else
-    M.builder = ResourceBuilder:new(definition.resource):view(definition, cancellationToken, { informer = false })
-  end
+
+  ResourceBuilder:view(definition, cancellationToken, { informer = false })
   if definition.res_type == "nodes" then
     definition.get_nodes()
   end


### PR DESCRIPTION
Reusing same window and buffer (we already reused buffer) to increase stability.

When not reusing window, it would be problematic to implement refresh in for example the log view where it would create a new one forcing us to manage closing the old one..

Right now I'm saving it into the builder instance but that might be overkill. The motivation is that it would act as a cancellation token when running things in parallell/async, you would check if the window is valid before acting on rendering anything. Otherwise we risk printing things to the incorrect buffer/window

Bonus:
- Instead of using a builder in every view, we use state to store it using definition.resource as an ID to decide if we want to create a new instance
- The fallback view precaching was running in a blocking way, made it a non blocking, first load is about 200ms quicker with this.

Solves #292 