### PR TITLE
feat: configurable kubectl command

### DIFF
--- a/ftplugin/k8s_pvc.lua
+++ b/ftplugin/k8s_pvc.lua
@@ -16,8 +16,8 @@ local function set_keymaps(bufnr)
       end
 
       -- get pv of pvc
-      local pv_name_args = { "get", "pvc", name, "-n", ns, "-o", 'jsonpath="{.spec.volumeName}"' }
-      local pv_name = commands.execute_shell_command("kubectl", pv_name_args)
+      local pv_name_args = { "get", "pvc", name, "-n", ns, "-o", "jsonpath={.spec.volumeName}" }
+      local pv_name = commands.shell_command("kubectl", pv_name_args)
 
       -- add to filter and view
       require("kubectl.state").filter = pv_name

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -13,8 +13,10 @@ function M.set_cmd(cmd, opts)
 
   table.insert(envs, "PATH=" .. current_env["PATH"])
   table.insert(envs, "HOME=" .. current_env["HOME"])
-  for _, env in ipairs(opts.env) do
-    table.insert(envs, env)
+  if opts and opts.env then
+    for _, env in ipairs(opts.env) do
+      table.insert(envs, env)
+    end
   end
   return cmd, envs
 end
@@ -139,10 +141,23 @@ function M.execute_terminal(cmd, args, opts)
   if type(args) == "table" then
     args = table.concat(args, " ")
   end
+  cmd, opts.env = M.set_cmd(cmd, opts)
+
+  local envs = {}
+  for _, env_var in ipairs(opts.env) do
+    local key, value = string.match(env_var, "^([^=]+)=(.+)$")
+    if key and value then
+      envs[key] = value
+    else
+      print("Invalid environment variable format: " .. env_var)
+    end
+  end
+
   local full_command = cmd .. " " .. args
 
   vim.fn.termopen(full_command, {
-    env = opts.env,
+    env = envs,
+    clear_env = true,
     stdin = opts.stdin,
     on_stdout = opts.on_stdout,
     on_exit = function(_, code, _)

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -150,6 +150,7 @@ function M.execute_shell_command(cmd, args)
 end
 
 --- Execute a command in a terminal
+--- NOTE: Don't use this for kubectl calls since this doesn't support clear_env
 --- @param cmd string The command to execute
 --- @param args string|string[] The arguments for the command
 function M.execute_terminal(cmd, args, opts)

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -5,12 +5,17 @@ function M.set_cmd(cmd, opts)
   local current_env = vim.fn.environ()
   if cmd == "kubectl" then
     cmd = config.options.kubectl_cmd.cmd
-    for _, env in ipairs(config.options.kubectl_cmd.env) do
-      table.insert(opts.env, env)
+    if opts.env then
+      for _, env in ipairs(config.options.kubectl_cmd.env) do
+        table.insert(opts.env, env)
+      end
     end
   end
-  table.insert(opts.env, "PATH=" .. current_env["PATH"])
-  table.insert(opts.env, "HOME=" .. current_env["HOME"])
+
+  if opts.env then
+    table.insert(opts.env, "PATH=" .. current_env["PATH"])
+    table.insert(opts.env, "HOME=" .. current_env["HOME"])
+  end
 end
 
 --- Execute a shell command synchronously

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -27,6 +27,10 @@ function M.configure_command(cmd, envs, args)
     end
   end
 
+  for key, value in pairs(result.env) do
+    result.env[key] = value:gsub("%$(%w+)", os.getenv)
+  end
+
   if args then
     for _, arg in ipairs(args) do
       table.insert(result.args, arg)

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -5,26 +5,21 @@ function M.configure_command(cmd, envs, args)
   local result = {
     env = {},
     args = {},
-    cmd = "",
   }
 
   local current_env = vim.fn.environ()
+
   if cmd == "kubectl" then
-    result.cmd = config.options.kubectl_cmd.cmd
-    for _, arg in ipairs(config.options.kubectl_cmd.args) do
-      table.insert(result.args, arg)
-    end
-    for _, env in ipairs(config.options.kubectl_cmd.env) do
-      table.insert(result.env, env)
-    end
+    cmd = config.options.kubectl_cmd.cmd
+    vim.list_extend(result.args, config.options.kubectl_cmd.args or {})
+    vim.list_extend(result.env, config.options.kubectl_cmd.env or {})
   end
 
   table.insert(result.env, "PATH=" .. current_env["PATH"])
   table.insert(result.env, "HOME=" .. current_env["HOME"])
+
   if envs then
-    for _, env in ipairs(envs) do
-      table.insert(result.env, env)
-    end
+    vim.list_extend(result.env, envs)
   end
 
   for key, value in pairs(result.env) do
@@ -32,12 +27,12 @@ function M.configure_command(cmd, envs, args)
   end
 
   if args then
-    for _, arg in ipairs(args) do
-      table.insert(result.args, arg)
-    end
+    vim.list_extend(result.args, args)
   end
 
+  -- Add the command itself as the first argument
   table.insert(result.args, 1, cmd)
+
   return result
 end
 

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -16,6 +16,7 @@ function M.set_cmd(cmd, opts)
     table.insert(opts.env, "PATH=" .. current_env["PATH"])
     table.insert(opts.env, "HOME=" .. current_env["HOME"])
   end
+  return cmd
 end
 
 --- Execute a shell command synchronously
@@ -28,7 +29,7 @@ function M.shell_command(cmd, args, opts)
   local result = ""
   local error_result = ""
 
-  M.set_cmd(cmd, opts)
+  cmd = M.set_cmd(cmd, opts)
   table.insert(args, 1, cmd)
 
   local job = vim.system(args, {
@@ -71,7 +72,7 @@ end
 function M.shell_command_async(cmd, args, on_exit, on_stdout, on_stderr, opts)
   opts = opts or { env = {} }
   local result = ""
-  M.set_cmd(cmd, opts)
+  cmd = M.set_cmd(cmd, opts)
   table.insert(args, 1, cmd)
 
   local handle = vim.system(args, {

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -1,3 +1,5 @@
+local commands = require("kubectl.actions.commands")
+local config = require("kubectl.config")
 local state = require("kubectl.state")
 
 local M = {}
@@ -33,8 +35,13 @@ function M.start_kubectl_proxy(callback)
       end
     end
   end
+  local cmd = "kubectl"
+  local opts = { env = {} }
+  commands.set_cmd(cmd, opts)
 
   local handle = vim.system({ "kubectl", "proxy", "--port=0" }, {
+    clear_env = true,
+    env = opts.env,
     stdin = false,
     stderr = false,
     stdout = on_stdout,

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -39,7 +39,7 @@ function M.start_kubectl_proxy(callback)
   cmd, opts.env = commands.set_cmd(cmd, opts)
 
   local handle = vim.system({ cmd, "proxy", "--port=0" }, {
-    clear_env = true,
+    clear_env = false,
     env = opts.env,
     stdin = false,
     stderr = function(_, data)

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -42,7 +42,13 @@ function M.start_kubectl_proxy(callback)
     clear_env = true,
     env = opts.env,
     stdin = false,
-    stderr = false,
+    stderr = function(err, data)
+      vim.schedule(function()
+        if data then
+          vim.notify(data, vim.log.levels.ERROR)
+        end
+      end)
+    end,
     stdout = on_stdout,
     detach = false,
   }, M.stop_kubectl_proxy())

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -36,7 +36,7 @@ function M.start_kubectl_proxy(callback)
   end
   local cmd = "kubectl"
   local opts = { env = {} }
-  commands.set_cmd(cmd, opts)
+  cmd = commands.set_cmd(cmd, opts)
 
   local handle = vim.system({ cmd, "proxy", "--port=0" }, {
     clear_env = true,

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -35,12 +35,11 @@ function M.start_kubectl_proxy(callback)
     end
   end
   local cmd = "kubectl"
-  local opts = { env = {} }
-  cmd, opts.env = commands.set_cmd(cmd, opts)
+  local command = commands.configure_command(cmd, {}, { "proxy", "--port=0" })
 
-  local handle = vim.system({ cmd, "proxy", "--port=0" }, {
+  local handle = vim.system(command.args, {
     clear_env = false,
-    env = opts.env,
+    env = command.env,
     stdin = false,
     stderr = function(_, data)
       vim.schedule(function()

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -38,8 +38,7 @@ function M.start_kubectl_proxy(callback)
   local command = commands.configure_command(cmd, {}, { "proxy", "--port=0" })
 
   local handle = vim.system(command.args, {
-    -- TODO: set this to true so that we can replace KUBECONFIG
-    clear_env = false,
+    clear_env = true,
     env = command.env,
     stdin = false,
     stderr = function(_, data)

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -36,13 +36,13 @@ function M.start_kubectl_proxy(callback)
   end
   local cmd = "kubectl"
   local opts = { env = {} }
-  cmd = commands.set_cmd(cmd, opts)
+  cmd, opts.env = commands.set_cmd(cmd, opts)
 
   local handle = vim.system({ cmd, "proxy", "--port=0" }, {
     clear_env = true,
     env = opts.env,
     stdin = false,
-    stderr = function(err, data)
+    stderr = function(_, data)
       vim.schedule(function()
         if data then
           vim.notify(data, vim.log.levels.ERROR)

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -1,5 +1,4 @@
 local commands = require("kubectl.actions.commands")
-local config = require("kubectl.config")
 local state = require("kubectl.state")
 
 local M = {}
@@ -39,7 +38,7 @@ function M.start_kubectl_proxy(callback)
   local opts = { env = {} }
   commands.set_cmd(cmd, opts)
 
-  local handle = vim.system({ "kubectl", "proxy", "--port=0" }, {
+  local handle = vim.system({ cmd, "proxy", "--port=0" }, {
     clear_env = true,
     env = opts.env,
     stdin = false,

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -38,6 +38,7 @@ function M.start_kubectl_proxy(callback)
   local command = commands.configure_command(cmd, {}, { "proxy", "--port=0" })
 
   local handle = vim.system(command.args, {
+    -- TODO: set this to true so that we can replace KUBECONFIG
     clear_env = false,
     env = command.env,
     stdin = false,

--- a/lua/kubectl/config.lua
+++ b/lua/kubectl/config.lua
@@ -17,6 +17,7 @@ local defaults = {
   diff = {
     bin = "kubediff",
   },
+  kubectl_cmd = { cmd = "kubectl", env = {} }, -- We will use this when invoking kubectl calls
   namespace = "All",
   namespace_fallback = {},
   notifications = {

--- a/lua/kubectl/config.lua
+++ b/lua/kubectl/config.lua
@@ -17,7 +17,11 @@ local defaults = {
   diff = {
     bin = "kubediff",
   },
-  kubectl_cmd = { cmd = "kubectl", env = {} }, -- We will use this when invoking kubectl calls
+  -- We will use this when invoking kubectl.
+  -- The subshells invoked will have PATH, HOME and the environments listed below
+  -- NOTE: Some executions using the io.open and vim.fn.terminal will still have default shell environments,
+  -- in that case, the environments below will not override the defaults
+  kubectl_cmd = { cmd = "kubectl", env = {} },
   namespace = "All",
   namespace_fallback = {},
   notifications = {

--- a/lua/kubectl/config.lua
+++ b/lua/kubectl/config.lua
@@ -20,8 +20,8 @@ local defaults = {
   -- We will use this when invoking kubectl.
   -- The subshells invoked will have PATH, HOME and the environments listed below
   -- NOTE: Some executions using the io.open and vim.fn.terminal will still have default shell environments,
-  -- in that case, the environments below will not override the defaults
-  kubectl_cmd = { cmd = "kubectl", env = {} },
+  -- in that case, the environments below will not override the defaults and should not be in your .zshrc/.bashrc files
+  kubectl_cmd = { cmd = "kubectl", env = {}, args = {} },
   namespace = "All",
   namespace_fallback = {},
   notifications = {

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -190,7 +190,7 @@ function M.set_and_open_pod_selector(kind, name, ns)
   local encode = vim.uri_encode
   local get_selectors = { "get", kind, name, "-n", ns, "-o", "json" }
   local resource = vim.json.decode(
-    commands.execute_shell_command("kubectl", get_selectors),
+    commands.shell_command("kubectl", get_selectors),
     { luanil = { object = true, array = true } }
   )
   local selector_t = resource.spec.selector.matchLabels or resource.metadata.labels


### PR DESCRIPTION
Fixes #305 

Example:
```
kubectl_cmd = { env = { "KUBECONFIG=$HOME/.kube/test" }, cmd = "kubectl" },
```

TODO:
- [x] execute_shell_command - I don't see how I can do this easily, maybe we should not use this for kubectl commands.
- [x] execute_terminal_command - there is no way to clear the defaults here
- [x] make it possible to use variables 
- [ ] make it possible to change these after setup function (in toggle for example)