### PR TITLE
feat: enhanced log with history value

### DIFF
--- a/ftplugin/k8s_container_logs.lua
+++ b/ftplugin/k8s_container_logs.lua
@@ -4,6 +4,7 @@ local str = require("kubectl.utils.string")
 
 mappings.map_if_plug_not_set("n", "f", "<Plug>(kubectl.follow)")
 mappings.map_if_plug_not_set("n", "gw", "<Plug>(kubectl.wrap)")
+mappings.map_if_plug_not_set("n", "gh", "<Plug>(kubectl.history)")
 mappings.map_if_plug_not_set("n", "<CR>", "<Plug>(kubectl.select)")
 
 --- Set key mappings for the buffer
@@ -33,6 +34,19 @@ local function set_keymaps(bufnr)
     desc = "Add divider",
     callback = function()
       str.divider(bufnr)
+    end,
+  })
+
+  vim.api.nvim_buf_set_keymap(bufnr, "n", "<Plug>(kubectl.history)", "", {
+    noremap = true,
+    silent = true,
+    desc = "Log history",
+    callback = function()
+      vim.ui.input({ prompt = "Since (seconds)=", default = pod_view.log_since }, function(input)
+        local container_view = require("kubectl.views.containers")
+        container_view.log_since = input
+        container_view.logs(pod_view.selection.pod, pod_view.selection.ns)
+      end)
     end,
   })
 end

--- a/ftplugin/k8s_pod_logs.lua
+++ b/ftplugin/k8s_pod_logs.lua
@@ -6,6 +6,7 @@ mappings.map_if_plug_not_set("n", "f", "<Plug>(kubectl.follow)")
 mappings.map_if_plug_not_set("n", "gw", "<Plug>(kubectl.wrap)")
 mappings.map_if_plug_not_set("n", "gp", "<Plug>(kubectl.prefix)")
 mappings.map_if_plug_not_set("n", "gt", "<Plug>(kubectl.timestamps)")
+mappings.map_if_plug_not_set("n", "gh", "<Plug>(kubectl.history)")
 mappings.map_if_plug_not_set("n", "<CR>", "<Plug>(kubectl.select)")
 
 --- Set key mappings for the buffer
@@ -39,6 +40,18 @@ local function set_keymaps(bufnr)
         pod_view.show_timestamps = "true"
       end
       pod_view.Logs()
+    end,
+  })
+
+  vim.api.nvim_buf_set_keymap(bufnr, "n", "<Plug>(kubectl.history)", "", {
+    noremap = true,
+    silent = true,
+    desc = "Log history",
+    callback = function()
+      vim.ui.input({ prompt = "Since (5s, 2m, 3h)=", default = pod_view.log_since }, function(input)
+        pod_view.log_since = input
+        pod_view.Logs()
+      end)
     end,
   })
 

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -42,7 +42,7 @@ function M.logs(pod, ns)
     syntax = "less",
     hints = {
       { key = "<Plug>(kubectl.follow)", desc = "Follow" },
-      { key = "<Plug>(kubectl.since)", desc = "History since: " .. M.log_since },
+      { key = "<Plug>(kubectl.history)", desc = "History [" .. M.log_since .. "]" },
       { key = "<Plug>(kubectl.wrap)", desc = "Wrap" },
     },
   })

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -3,8 +3,10 @@ local buffers = require("kubectl.actions.buffers")
 local commands = require("kubectl.actions.commands")
 local definition = require("kubectl.views.containers.definition")
 
-local M = {}
-M.selection = {}
+local M = {
+  selection = {},
+  log_since = "300",
+}
 
 function M.selectContainer(name)
   M.selection = name
@@ -27,11 +29,20 @@ function M.logs(pod, ns)
     resource = "containerLogs",
     ft = "k8s_container_logs",
     url = {
-      "{{BASE}}/api/v1/namespaces/" .. ns .. "/pods/" .. pod .. "/log/?container=" .. M.selection .. "&pretty=true",
+      "{{BASE}}/api/v1/namespaces/"
+        .. ns
+        .. "/pods/"
+        .. pod
+        .. "/log/?container="
+        .. M.selection
+        .. "&pretty=true"
+        .. "&sinceSeconds="
+        .. M.log_since,
     },
     syntax = "less",
     hints = {
       { key = "<Plug>(kubectl.follow)", desc = "Follow" },
+      { key = "<Plug>(kubectl.since)", desc = "History since: " .. M.log_since },
       { key = "<Plug>(kubectl.wrap)", desc = "Wrap" },
     },
   })

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -12,6 +12,7 @@ local M = {
   tail_handle = nil,
   -- TODO: should propably be configurable
   show_log_prefix = "true",
+  log_since = "5m",
   show_timestamps = "true",
 }
 
@@ -92,6 +93,7 @@ function M.Logs()
     url = {
       "logs",
       "--all-containers=true",
+      "--since=" .. M.log_since,
       "--prefix=" .. M.show_log_prefix,
       "--timestamps=" .. M.show_timestamps,
       M.selection.pod,
@@ -101,9 +103,10 @@ function M.Logs()
     syntax = "less",
     hints = {
       { key = "<Plug>(kubectl.follow)", desc = "Follow" },
-      { key = "<Plug>(kubectl.wrap)", desc = "Wrap" },
+      { key = "<Plug>(kubectl.since)", desc = "History: " .. M.log_since },
       { key = "<Plug>(kubectl.prefix)", desc = "Prefix" },
       { key = "<Plug>(kubectl.timestamps)", desc = "Timestamps" },
+      { key = "<Plug>(kubectl.wrap)", desc = "Wrap" },
     },
   }
 

--- a/lua/kubectl/views/pods/init.lua
+++ b/lua/kubectl/views/pods/init.lua
@@ -103,7 +103,7 @@ function M.Logs()
     syntax = "less",
     hints = {
       { key = "<Plug>(kubectl.follow)", desc = "Follow" },
-      { key = "<Plug>(kubectl.since)", desc = "History: " .. M.log_since },
+      { key = "<Plug>(kubectl.history)", desc = "History [" .. M.log_since .. "]" },
       { key = "<Plug>(kubectl.prefix)", desc = "Prefix" },
       { key = "<Plug>(kubectl.timestamps)", desc = "Timestamps" },
       { key = "<Plug>(kubectl.wrap)", desc = "Wrap" },


### PR DESCRIPTION
Use since to determine how far back logs are viewed.
Default set to 5m, the individual container uses curl to fetch logs and only accepts seconds so default is 300 seconds for container logs


Fixes #307 

Bonus:
Added current value into the hints menu