### PR TITLE
Fix/pods row status nil

### DIFF
--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -38,7 +38,7 @@ local function getReady(row)
 end
 
 --- Get restarts as a symbol
----@param row table<table>
+---@param row table
 ---@param currentTime number
 ---@return table
 local function getRestarts(row, currentTime)

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -41,7 +41,8 @@ end
 ---@param containerStatuses table<table>
 ---@param currentTime number
 ---@return table
-local function getRestarts(containerStatuses, currentTime)
+local function getRestarts(row, currentTime)
+  local containerStatuses = row.status and row.status.containerStatuses
   local restarts = { symbol = "", value = "0", sort_by = 0 }
   if not containerStatuses then
     return restarts
@@ -148,6 +149,9 @@ local function getContainerStatus(pod_status, status)
 end
 
 local function getPodStatus(row)
+  if not row.status then
+    return { value = "Unknown", symbol = events.ColorStatus("Unknown") }
+  end
   local status = row.status.phase
   local ok
 
@@ -191,7 +195,7 @@ function M.processRow(rows)
         name = row.metadata.name,
         ready = getReady(row),
         status = getPodStatus(row),
-        restarts = getRestarts(row.status.containerStatuses, currentTime),
+        restarts = getRestarts(row, currentTime),
         ip = row.status.podIP or "",
         node = row.spec.nodeName,
         age = time.since(row.metadata.creationTimestamp, true, currentTime),

--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -38,7 +38,7 @@ local function getReady(row)
 end
 
 --- Get restarts as a symbol
----@param containerStatuses table<table>
+---@param row table<table>
 ---@param currentTime number
 ---@return table
 local function getRestarts(row, currentTime)


### PR DESCRIPTION
I get many times an error where `row.status` is `nil`.

I tested it on a cluster with a number of weird pods without status and it doesn't bring the errors back.