### PR TITLE
fix: don't include port in the url when 443 or 80

### DIFF
--- a/ftplugin/k8s_ingresses.lua
+++ b/ftplugin/k8s_ingresses.lua
@@ -62,8 +62,7 @@ local function set_keymap(bufnr)
           local proto = port == "443" and "https" or "http"
           local url = ""
           if port ~= "443" and port ~= "80" then
-            port = ":" .. port
-            url = string.format("%s://%s%s", proto, host, port)
+            url = string.format("%s://%s:%s", proto, host, port)
           else
             url = string.format("%s://%s", proto, host)
           end

--- a/ftplugin/k8s_ingresses.lua
+++ b/ftplugin/k8s_ingresses.lua
@@ -60,10 +60,14 @@ local function set_keymap(bufnr)
             end
           end
           local proto = port == "443" and "https" or "http"
+          local url = ""
           if port ~= "443" and port ~= "80" then
             port = ":" .. port
+            url = string.format("%s://%s%s", proto, host, port)
+          else
+            url = string.format("%s://%s", proto, host)
           end
-          vim.ui.open(string.format("%s://%s%s", proto, host, port))
+          vim.ui.open(url)
         end)
     end,
   })


### PR DESCRIPTION
When browsing to a host that has 80 or 443 as port number we are getting http://url80