### PR TITLE
fix: dancing divider

### DIFF
--- a/lua/kubectl/utils/grid.lua
+++ b/lua/kubectl/utils/grid.lua
@@ -123,14 +123,13 @@ function M.pretty_print(data, sections)
     end
     local header_row = table.concat(current_headers, pipe)
 
-    if #layout > 2 then
-      table.insert(extmarks, {
-        row = #layout - 1,
-        start_col = 0,
-        virt_text = { { string.rep(dash, #header_row), hl.symbols.success } },
-        virt_text_pos = "overlay",
-      })
-    end
+    table.insert(layout, "")
+    table.insert(extmarks, {
+      row = #layout - 1,
+      start_col = 0,
+      virt_text = { { string.rep(dash, #header_row), hl.symbols.success } },
+      virt_text_pos = "overlay",
+    })
     table.insert(layout, header_row)
     table.insert(extmarks, { row = #layout - 1, start_col = 0, end_col = #header_row, hl_group = hl.symbols.header })
     table.insert(layout, "")

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -129,14 +129,13 @@ local function addDividerRow(divider, hints, marks)
   local win_width = vim.api.nvim_win_get_width(win)
   local text_width = win_width - vim.fn.getwininfo(win)[1].textoff
   local half_width = math.floor(text_width / 2)
-
   local row = " "
   if divider then
     local resource = divider.resource or ""
     local count = divider.count or ""
     local filter = divider.filter or ""
     local info = resource .. count .. filter
-    local padding = string.rep("―", half_width - #info / 2)
+    local padding = string.rep("-", half_width - math.floor(#info / 2))
 
     local virt_text = {
       { padding, hl.symbols.success },
@@ -160,7 +159,7 @@ local function addDividerRow(divider, hints, marks)
       virt_text_pos = "overlay",
     })
   else
-    local padding = string.rep("―", half_width)
+    local padding = string.rep("-", half_width)
     row = padding .. padding
     table.insert(marks, {
       row = #hints,


### PR DESCRIPTION
The issue seems to be the width / 2 resulting in fractals, sometimes it rounded up and sometimes down.
Also changed the unicode character to a normal dash, since I found some weirdness on different font-sizes and different terminals.

Kept the unicode in overview to differentiate between grid

Fixes: #313 