### PR TITLE
fix/secret-desc-error-and-hint

### DIFF
--- a/ftplugin/k8s_secret_desc.lua
+++ b/ftplugin/k8s_secret_desc.lua
@@ -12,7 +12,11 @@ local function set_keymaps(bufnr)
 
       local code = line:match(":%s*(.+)")
       if code then
-        local decoded = vim.base64.decode(code)
+        local dec_ok, decoded = pcall(vim.base64.decode, code)
+        if not dec_ok then
+          vim.notify("Failed to decode base64: " .. decoded)
+          return
+        end
         line = line:gsub(code, decoded)
 
         local decoded_lines = vim.split(line, "\n", true)

--- a/lua/kubectl/views/secrets/init.lua
+++ b/lua/kubectl/views/secrets/init.lua
@@ -28,7 +28,7 @@ function M.Desc(name, ns, reload)
     url = { "get", "secret", name, "-n", ns, "-o", "yaml" },
     syntax = "yaml",
     hints = {
-      { key = "<cr>", desc = "base64decode" },
+      { key = "<Plug>(kubectl.select)", desc = "base64decode" },
     },
   }, { cmd = "kubectl" })
 end


### PR DESCRIPTION
fix base64 decode errors that we don't wanna see and display the right Hint for secret describe float