### PR TITLE
feat/svc-go-to-pods

### DIFF
--- a/ftplugin/k8s_services.lua
+++ b/ftplugin/k8s_services.lua
@@ -8,6 +8,7 @@ local mappings = require("kubectl.mappings")
 local overview_view = require("kubectl.views.overview")
 local service_view = require("kubectl.views.services")
 local tables = require("kubectl.utils.tables")
+local view = require("kubectl.views")
 
 mappings.map_if_plug_not_set("n", "gp", "<Plug>(kubectl.portforward)")
 
@@ -19,6 +20,16 @@ local function set_keymap(bufnr)
     desc = "Go up",
     callback = function()
       overview_view.View()
+    end,
+  })
+
+  api.nvim_buf_set_keymap(bufnr, "n", "<Plug>(kubectl.select)", "", {
+    noremap = true,
+    silent = true,
+    desc = "Go to pods",
+    callback = function()
+      local name, ns = service_view.getCurrentSelection()
+      view.set_and_open_pod_selector("service", name, ns)
     end,
   })
 

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -219,7 +219,8 @@ function M.set_and_open_pod_selector(kind, name, ns)
   local get_selectors = { "get", kind, name, "-n", ns, "-o", "json" }
   local resource =
     vim.json.decode(commands.shell_command("kubectl", get_selectors), { luanil = { object = true, array = true } })
-  local selector_t = resource.spec.selector.matchLabels or resource.metadata.labels
+  local selector_t = (resource.spec.selector and resource.spec.selector.matchLabels or resource.spec.selector)
+    or resource.metadata.labels
   local key_value_pairs = vim.tbl_map(function(key)
     return encode(key .. "=" .. selector_t[key])
   end, vim.tbl_keys(selector_t))

--- a/lua/kubectl/views/services/definition.lua
+++ b/lua/kubectl/views/services/definition.lua
@@ -4,6 +4,7 @@ local M = {
   ft = "k8s_services",
   url = { "{{BASE}}/api/v1/{{NAMESPACE}}services?pretty=false" },
   hints = {
+    { key = "<Plug>(kubectl.select)", desc = "pods", long_desc = "Opens pods view" },
     { key = "<Plug>(kubectl.portforward)", desc = "Port forward", long_desc = "Port forward" },
   },
 }


### PR DESCRIPTION
Clicking `<CR>` (or whatever the user defined as `<Plug>(kubectl.select)` on `Services` view shows us the relevant pods of the service.