### PR TITLE
fix/health-on-fallback-view

### DIFF
--- a/lua/kubectl/views/fallback/definition.lua
+++ b/lua/kubectl/views/fallback/definition.lua
@@ -50,7 +50,11 @@ local function getStatus(row)
   end
 
   if row.status.health then
-    return { symbol = events.ColorStatus(string_utils.capitalize(row.status.health)), value = row.status.health }
+    local health = row.status.health.status or row.status.health
+    return {
+      symbol = events.ColorStatus(health),
+      value = health,
+    }
   end
 end
 


### PR DESCRIPTION
noticed this:
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/c63d174b-4f30-4f85-b43c-94792eff7cf9">

I have a resource `Applications` (argocd) where the `row.status.health` is a table with key `status`