### PR TITLE
fix/fallback-age-column

### DIFF
--- a/lua/kubectl/utils/time.lua
+++ b/lua/kubectl/utils/time.lua
@@ -20,6 +20,9 @@ function M.since(timestamp, fresh, currentTime)
   end
 
   local parsed_time = vim.fn.strptime("%Y-%m-%dT%H:%M:%SZ", timestamp)
+  if not parsed_time or parsed_time == 0 then
+    return nil
+  end
 
   local diff = currentTime - parsed_time
   local days = math.floor(diff / 86400)

--- a/lua/kubectl/views/fallback/definition.lua
+++ b/lua/kubectl/views/fallback/definition.lua
@@ -1,5 +1,4 @@
 local events = require("kubectl.utils.events")
-local string_utils = require("kubectl.utils.string")
 local tables = require("kubectl.utils.tables")
 local time = require("kubectl.utils.time")
 local M = {
@@ -74,7 +73,14 @@ function M.processRow(rows)
         resource.namespace = namespace
       end
       for i, val in pairs(resource_vals) do
-        resource[string.lower(rows.columnDefinitions[i].name)] = { value = val or "", symbol = events.ColorStatus(val) }
+        local res_key = string.lower(rows.columnDefinitions[i].name)
+        local is_time = time.since(val)
+        -- if the value parsed as time, then it's age/created at column
+        if is_time then
+          resource[res_key] = is_time
+        else
+          resource[res_key] = { value = val or "", symbol = events.ColorStatus(val) }
+        end
       end
       table.insert(data, resource)
     end


### PR DESCRIPTION
on some fallback views (most commonly for me is Roles and ClusterRoles), there are `CREATED_AT` columns:
<img width="601" alt="image" src="https://github.com/user-attachments/assets/56fdfaf0-9a26-4bb9-a009-7af4b55cac0b">

I think we can always test if the value is a parsable timestamp, and if so, use it

result:
<img width="661" alt="image" src="https://github.com/user-attachments/assets/6a734bd8-9e49-498c-ae5b-dde249652128">
