### PR TITLE
feat/use-data-for-resource

### DIFF
--- a/ftplugin/k8s_daemonsets.lua
+++ b/ftplugin/k8s_daemonsets.lua
@@ -19,7 +19,7 @@ local function set_keymaps(bufnr)
     desc = "Go to pods",
     callback = function()
       local name, ns = daemonset_view.getCurrentSelection()
-      view.set_and_open_pod_selector("daemonsets", name, ns)
+      view.set_and_open_pod_selector(name, ns)
     end,
   })
 

--- a/ftplugin/k8s_daemonsets.lua
+++ b/ftplugin/k8s_daemonsets.lua
@@ -31,6 +31,9 @@ local function set_keymaps(bufnr)
     callback = function()
       local name, ns = daemonset_view.getCurrentSelection()
       local resource = tables.find_resource(state.instance.data, name, ns)
+      if not resource then
+        return
+      end
 
       local containers = {}
 

--- a/ftplugin/k8s_deployments.lua
+++ b/ftplugin/k8s_deployments.lua
@@ -21,7 +21,7 @@ local function set_keymaps(bufnr)
     desc = "Go to pods",
     callback = function()
       local name, ns = deployment_view.getCurrentSelection()
-      view.set_and_open_pod_selector("deployments", name, ns)
+      view.set_and_open_pod_selector(name, ns)
     end,
   })
 

--- a/ftplugin/k8s_ingresses.lua
+++ b/ftplugin/k8s_ingresses.lua
@@ -1,5 +1,4 @@
 local api = vim.api
-local ResourceBuilder = require("kubectl.resourcebuilder")
 local ingresses_view = require("kubectl.views.ingresses")
 local loop = require("kubectl.utils.loop")
 local mappings = require("kubectl.mappings")

--- a/ftplugin/k8s_ingresses.lua
+++ b/ftplugin/k8s_ingresses.lua
@@ -3,6 +3,8 @@ local ResourceBuilder = require("kubectl.resourcebuilder")
 local ingresses_view = require("kubectl.views.ingresses")
 local loop = require("kubectl.utils.loop")
 local mappings = require("kubectl.mappings")
+local state = require("kubectl.state")
+local tables = require("kubectl.utils.tables")
 
 mappings.map_if_plug_not_set("n", "gx", "<Plug>(kubectl.browse)")
 
@@ -14,51 +16,48 @@ local function set_keymap(bufnr)
     desc = "Open host in browser",
     callback = function()
       local name, ns = ingresses_view.getCurrentSelection()
-      ResourceBuilder:new("ingress_host")
-        :setCmd({ "get", "ingress", name, "-n", ns, "-o", "json" }, "kubectl")
-        :fetchAsync(function(self)
-          self:decodeJson()
-          local data = self.data
+      local resource = tables.find_resource(state.instance.data, name, ns)
+      if not resource then
+        return
+      end
+      -- determine port
+      local port = ""
+      if
+        resource.spec.rules
+        and resource.spec.rules[1]
+        and resource.spec.rules[1].http
+        and resource.spec.rules[1].http.paths
+        and resource.spec.rules[1].http.paths[1]
+        and resource.spec.rules[1].http.paths[1].backend
+      then
+        local backend = resource.spec.rules[1].http.paths[1].backend
+        port = backend.service.port.number or backend.servicePort or "80"
+      end
 
-          -- determine port
-          local port = ""
-          if
-            data.spec.rules
-            and data.spec.rules[1]
-            and data.spec.rules[1].http
-            and data.spec.rules[1].http.paths
-            and data.spec.rules[1].http.paths[1]
-            and data.spec.rules[1].http.paths[1].backend
-          then
-            local backend = data.spec.rules[1].http.paths[1].backend
-            port = backend.service.port.number or backend.servicePort or "80"
+      -- determine host
+      local host = ""
+      if resource.spec.rules and resource.spec.rules[1] and resource.spec.rules[1].host then
+        host = resource.spec.rules[1].host
+      else
+        if resource.status and resource.status.loadBalancer and resource.status.loadBalancer.ingress then
+          local ingress = resource.status.loadBalancer.ingress[1]
+          if ingress.hostname then
+            host = ingress.hostname
+          elseif ingress.ip then
+            host = ingress.ip
           end
-
-          -- determine host
-          local host = ""
-          if data.spec.rules and data.spec.rules[1] and data.spec.rules[1].host then
-            host = data.spec.rules[1].host
-          else
-            if data.status and data.status.loadBalancer and data.status.loadBalancer.ingress then
-              local ingress = data.status.loadBalancer.ingress[1]
-              if ingress.hostname then
-                host = ingress.hostname
-              elseif ingress.ip then
-                host = ingress.ip
-              end
-            else
-              return
-            end
-          end
-          local proto = port == "443" and "https" or "http"
-          local url = ""
-          if port ~= "443" and port ~= "80" then
-            url = string.format("%s://%s:%s", proto, host, port)
-          else
-            url = string.format("%s://%s", proto, host)
-          end
-          vim.ui.open(url)
-        end)
+        else
+          return
+        end
+      end
+      local proto = port == "443" and "https" or "http"
+      local url = ""
+      if port ~= "443" and port ~= "80" then
+        url = string.format("%s://%s:%s", proto, host, port)
+      else
+        url = string.format("%s://%s", proto, host)
+      end
+      vim.ui.open(url)
     end,
   })
 end

--- a/ftplugin/k8s_jobs.lua
+++ b/ftplugin/k8s_jobs.lua
@@ -15,7 +15,7 @@ local function set_keymaps(bufnr)
     desc = "Go to pods",
     callback = function()
       local name, ns = job_view.getCurrentSelection()
-      view.set_and_open_pod_selector("jobs", name, ns)
+      view.set_and_open_pod_selector(name, ns)
     end,
   })
 

--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -8,6 +8,7 @@ local loop = require("kubectl.utils.loop")
 local mappings = require("kubectl.mappings")
 local pod_view = require("kubectl.views.pods")
 local root_definition = require("kubectl.views.definition")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
 mappings.map_if_plug_not_set("n", "gl", "<Plug>(kubectl.logs)")
@@ -83,103 +84,98 @@ local function set_keymaps(bufnr)
         return
       end
 
-      ResourceBuilder:new("pods_pf")
-        :setCmd({
-          "{{BASE}}/api/v1/namespaces/" .. ns .. "/pods/" .. name .. "?pretty=false",
-        }, "curl")
-        :fetchAsync(function(self)
-          self:decodeJson()
-          local data = {}
-          for _, container in ipairs(self.data.spec.containers) do
-            if container.ports then
-              for _, port in ipairs(container.ports) do
-                table.insert(data, {
-                  name = { value = port.name, symbol = hl.symbols.pending },
-                  port = { value = port.containerPort, symbol = hl.symbols.success },
-                  protocol = port.protocol,
-                })
-              end
+      local resource = tables.find_resource(state.instance.data, name, ns)
+      if not resource then
+        return
+      end
+
+      local self = ResourceBuilder:new("pods_pf")
+      local data = {}
+      for _, container in ipairs(resource.spec.containers) do
+        if container.ports then
+          for _, port in ipairs(container.ports) do
+            table.insert(data, {
+              name = { value = port.name, symbol = hl.symbols.pending },
+              port = { value = port.containerPort, symbol = hl.symbols.success },
+              protocol = port.protocol,
+            })
+          end
+        end
+      end
+
+      vim.schedule(function()
+        if next(data) == nil then
+          api.nvim_err_writeln("No container ports exposed in pod")
+          return
+        end
+
+        local win_config
+        self.buf_nr, win_config = buffers.confirmation_buffer("Confirm port forward", "PortForward", function(confirm)
+          if not confirm then
+            return
+          end
+          local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+          local container_port, local_port
+
+          local port_pattern = ".+:%s*(%d+)"
+          for _, line in ipairs(lines) do
+            if line:match("Container port:") then
+              container_port = line:match(port_pattern)
+            elseif line:match("Local port:") then
+              local_port = line:match(port_pattern)
             end
           end
+          if not container_port or not local_port then
+            api.nvim_err_writeln("Failed to extract container port or local port")
+            return
+          end
+          commands.shell_command_async(
+            "kubectl",
+            { "port-forward", "-n", ns, "pods/" .. name, local_port .. ":" .. container_port }
+          )
 
           vim.schedule(function()
-            if next(data) == nil then
-              api.nvim_err_writeln("No container ports exposed in pod")
-              return
-            end
-
-            local win_config
-            self.buf_nr, win_config = buffers.confirmation_buffer(
-              "Confirm port forward",
-              "PortForward",
-              function(confirm)
-                if not confirm then
-                  return
-                end
-                local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-                local container_port, local_port
-
-                local port_pattern = ".+:%s*(%d+)"
-                for _, line in ipairs(lines) do
-                  if line:match("Container port:") then
-                    container_port = line:match(port_pattern)
-                  elseif line:match("Local port:") then
-                    local_port = line:match(port_pattern)
-                  end
-                end
-                if not container_port or not local_port then
-                  api.nvim_err_writeln("Failed to extract container port or local port")
-                  return
-                end
-                commands.shell_command_async(
-                  "kubectl",
-                  { "port-forward", "-n", ns, "pods/" .. name, local_port .. ":" .. container_port }
-                )
-
-                vim.schedule(function()
-                  pod_view.View()
-                end)
-              end
-            )
-
-            self.prettyData, self.extmarks = tables.pretty_print(data, { "NAME", "PORT", "PROTOCOL" })
-
-            table.insert(self.prettyData, "")
-            table.insert(self.prettyData, "Container port: " .. data[1].port.value)
-            table.insert(self.prettyData, "Local port:     " .. data[1].port.value)
-            table.insert(self.prettyData, "")
-
-            local confirmation = "[y]es [n]o | `gr` to reset"
-            local padding = string.rep(" ", (win_config.width - #confirmation) / 2)
-            table.insert(self.prettyData, padding .. confirmation)
-
-            local original_data = vim.deepcopy(self.prettyData)
-
-            self:setContent()
-            api.nvim_buf_set_keymap(self.buf_nr, "n", "gr", "", {
-              noremap = true,
-              silent = true,
-              desc = "Reset",
-              callback = function()
-                self.prettyData = original_data
-                self:setContent()
-              end,
-            })
-            api.nvim_buf_set_keymap(self.buf_nr, "n", "<CR>", "", {
-              noremap = true,
-              silent = true,
-              desc = "Change container port",
-              callback = function()
-                local port_ok, port = pcall(tables.getCurrentSelection, 2)
-                if not port_ok or not port or not tonumber(port) then
-                  return
-                end
-                local line = "Container port: " .. port
-                api.nvim_buf_set_lines(self.buf_nr, #self.prettyData - 4, #self.prettyData - 3, false, { line })
-              end,
-            })
+            pod_view.View()
           end)
         end)
+
+        self.prettyData, self.extmarks = tables.pretty_print(data, { "NAME", "PORT", "PROTOCOL" })
+
+        table.insert(self.prettyData, "")
+        table.insert(self.prettyData, "Container port: " .. data[1].port.value)
+        table.insert(self.prettyData, "Local port:     " .. data[1].port.value)
+        table.insert(self.prettyData, "")
+
+        local confirmation = "[y]es [n]o | `gr` to reset"
+        local padding = string.rep(" ", (win_config.width - #confirmation) / 2)
+        table.insert(self.prettyData, padding .. confirmation)
+
+        local original_data = vim.deepcopy(self.prettyData)
+
+        self:setContent()
+        api.nvim_buf_set_keymap(self.buf_nr, "n", "gr", "", {
+          noremap = true,
+          silent = true,
+          desc = "Reset",
+          callback = function()
+            self.prettyData = original_data
+            self:setContent()
+          end,
+        })
+        api.nvim_buf_set_keymap(self.buf_nr, "n", "<CR>", "", {
+          noremap = true,
+          silent = true,
+          desc = "Change container port",
+          callback = function()
+            local port_ok, port = pcall(tables.getCurrentSelection, 2)
+            if not port_ok or not port or not tonumber(port) then
+              return
+            end
+            local line = "Container port: " .. port
+            api.nvim_buf_set_lines(self.buf_nr, #self.prettyData - 4, #self.prettyData - 3, false, { line })
+          end,
+        })
+      end)
     end,
   })
 end

--- a/ftplugin/k8s_pvc.lua
+++ b/ftplugin/k8s_pvc.lua
@@ -1,6 +1,7 @@
-local commands = require("kubectl.actions.commands")
 local loop = require("kubectl.utils.loop")
 local pvc_view = require("kubectl.views.pvc")
+local state = require("kubectl.state")
+local tables = require("kubectl.utils.tables")
 
 --- Set key mappings for the buffer
 local function set_keymaps(bufnr)
@@ -16,8 +17,12 @@ local function set_keymaps(bufnr)
       end
 
       -- get pv of pvc
-      local pv_name_args = { "get", "pvc", name, "-n", ns, "-o", "jsonpath={.spec.volumeName}" }
-      local pv_name = commands.shell_command("kubectl", pv_name_args)
+
+      local resource = tables.find_resource(state.instance.data, name, ns)
+      if not resource then
+        return
+      end
+      local pv_name = resource.spec.volumeName
 
       -- add to filter and view
       require("kubectl.state").filter = pv_name

--- a/ftplugin/k8s_services.lua
+++ b/ftplugin/k8s_services.lua
@@ -6,6 +6,7 @@ local hl = require("kubectl.actions.highlight")
 local loop = require("kubectl.utils.loop")
 local mappings = require("kubectl.mappings")
 local service_view = require("kubectl.views.services")
+local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 local view = require("kubectl.views")
 
@@ -34,68 +35,62 @@ local function set_keymap(bufnr)
         api.nvim_err_writeln("Failed to select service for port forward")
         return
       end
+      local resource = tables.find_resource(state.instance.data, name, ns)
+      if not resource then
+        return
+      end
 
-      ResourceBuilder:new("services_pf")
-        :setCmd({
-          "{{BASE}}/api/v1/namespaces/" .. ns .. "/services/" .. name .. "?pretty=false",
-        }, "curl")
-        :fetchAsync(function(self)
-          self:decodeJson()
-          local data = {}
+      local self = ResourceBuilder:new("services_pf")
+      local data = {}
 
-          for _, port in ipairs(self.data.spec.ports) do
-            table.insert(data, {
-              name = { value = port.name, symbol = hl.symbols.pending },
-              port = { value = port.port, symbol = hl.symbols.success },
-              protocol = port.protocol,
-            })
-          end
+      for _, port in ipairs(resource.spec.ports) do
+        table.insert(data, {
+          name = { value = port.name, symbol = hl.symbols.pending },
+          port = { value = port.port, symbol = hl.symbols.success },
+          protocol = port.protocol,
+        })
+      end
 
-          vim.schedule(function()
-            local win_config
-            self.buf_nr, win_config = buffers.confirmation_buffer(
-              "Confirm port forward",
-              "PortForward",
-              function(confirm)
-                if confirm then
-                  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-                  local container_port, local_port
+      vim.schedule(function()
+        local win_config
+        self.buf_nr, win_config = buffers.confirmation_buffer("Confirm port forward", "PortForward", function(confirm)
+          if confirm then
+            local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+            local container_port, local_port
 
-                  for _, line in ipairs(lines) do
-                    if line:match("Container port:") then
-                      container_port = line:match("::(%d+)$")
-                    elseif line:match("Local port:") then
-                      local_port = line:match("Local port: (.*)")
-                    end
-                  end
-                  commands.shell_command_async(
-                    "kubectl",
-                    { "port-forward", "-n", ns, "svc/" .. name, local_port .. ":" .. container_port }
-                  )
-
-                  vim.schedule(function()
-                    service_view.View()
-                  end)
-                end
+            for _, line in ipairs(lines) do
+              if line:match("Container port:") then
+                container_port = line:match("::(%d+)$")
+              elseif line:match("Local port:") then
+                local_port = line:match("Local port: (.*)")
               end
+            end
+            commands.shell_command_async(
+              "kubectl",
+              { "port-forward", "-n", ns, "svc/" .. name, local_port .. ":" .. container_port }
             )
 
-            self.prettyData, self.extmarks = tables.pretty_print(data, { "NAME", "PORT", "PROTOCOL" })
-
-            table.insert(self.prettyData, "")
-            table.insert(
-              self.prettyData,
-              "Container port: " .. (data[1].name.value or "<unset>") .. "::" .. data[1].port.value
-            )
-            table.insert(self.prettyData, "Local port: " .. data[1].port.value)
-            table.insert(self.prettyData, "")
-            local confirmation = "[y]es [n]o:"
-            local padding = string.rep(" ", (win_config.width - #confirmation) / 2)
-            table.insert(self.prettyData, padding .. confirmation)
-
-            self:setContent()
-          end)
+            vim.schedule(function()
+              service_view.View()
+            end)
+          end
         end)
+
+        self.prettyData, self.extmarks = tables.pretty_print(data, { "NAME", "PORT", "PROTOCOL" })
+
+        table.insert(self.prettyData, "")
+        table.insert(
+          self.prettyData,
+          "Container port: " .. (data[1].name.value or "<unset>") .. "::" .. data[1].port.value
+        )
+        table.insert(self.prettyData, "Local port: " .. data[1].port.value)
+        table.insert(self.prettyData, "")
+        local confirmation = "[y]es [n]o:"
+        local padding = string.rep(" ", (win_config.width - #confirmation) / 2)
+        table.insert(self.prettyData, padding .. confirmation)
+
+        self:setContent()
+      end)
     end,
   })
 end

--- a/ftplugin/k8s_services.lua
+++ b/ftplugin/k8s_services.lua
@@ -20,7 +20,7 @@ local function set_keymap(bufnr)
     desc = "Go to pods",
     callback = function()
       local name, ns = service_view.getCurrentSelection()
-      view.set_and_open_pod_selector("service", name, ns)
+      view.set_and_open_pod_selector(name, ns)
     end,
   })
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -347,6 +347,20 @@ function M.getCurrentSelection(...)
   return unpack(results)
 end
 
+function M.find_resource(data, name, namespace)
+  if data.items then
+    return vim.iter(data.items):find(function(row)
+      return row.metadata.name == name and row.metadata.namespace == namespace
+    end)
+  end
+  if data.rows then
+    return vim.iter(data.rows):find(function(row)
+      return row.object.metadata.name == name and row.object.metadata.namespace == namespace
+    end)
+  end
+  return nil
+end
+
 --- Check if a table is empty
 ---@param table table
 ---@return boolean

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -347,6 +347,15 @@ function M.getCurrentSelection(...)
   return unpack(results)
 end
 
+function M.find_index(haystack, needle)
+  for index, value in ipairs(haystack) do
+    if value == needle then
+      return index
+    end
+  end
+  return nil -- Return nil if the needle is not found
+end
+
 function M.find_resource(data, name, namespace)
   if data.items then
     return vim.iter(data.items):find(function(row)

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -347,15 +347,6 @@ function M.getCurrentSelection(...)
   return unpack(results)
 end
 
-function M.find_index(haystack, needle)
-  for index, value in ipairs(haystack) do
-    if value == needle then
-      return index
-    end
-  end
-  return nil -- Return nil if the needle is not found
-end
-
 function M.find_resource(data, name, namespace)
   if data.items then
     return vim.iter(data.items):find(function(row)

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -208,9 +208,10 @@ function M.UserCmd(args)
   end)
 end
 
-function M.set_and_open_pod_selector(kind, name, ns)
+function M.set_and_open_pod_selector(name, ns)
   local pod_view = require("kubectl.views.pods")
-  if not kind or not name or not ns then
+  local kind = state.instance.resource
+  if  not name or not ns then
     return pod_view.View()
   end
 

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -221,9 +221,10 @@ function M.set_and_open_pod_selector(kind, name, ns)
 
   -- get the selectors for the pods
   local encode = vim.uri_encode
-  local get_selectors = { "get", kind, name, "-n", ns, "-o", "json" }
-  local resource =
-    vim.json.decode(commands.shell_command("kubectl", get_selectors), { luanil = { object = true, array = true } })
+  local resource = tables.find_resource(state.instance.data, name, ns)
+  if not resource then
+    return
+  end
   local selector_t = (resource.spec.selector and resource.spec.selector.matchLabels or resource.spec.selector)
     or resource.metadata.labels
   local key_value_pairs = vim.tbl_map(function(key)


### PR DESCRIPTION
on k8s_ ftplugins on some keymaps, we get the user selection and then do `kubectl get resource name -n namespace -ojson`

but why?
we already have all the resource data!
`find_resource` function to the rescue

this makes the stuff changed blazingly fast.
change image, scale deployment, browse ingress
we don't have to wait to fetch the resource again, we just search for it.

it looks like a big PR with many changes but in reality I just went outside of the resource builder `fetchAsync()` that's why I had to indent everything back and it looks like many changes.

try it @Ramilito  i think you'd like it