### PR TITLE
docs: highlight-and-keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,50 +93,62 @@ vim.keymap.set("n", "<leader>k", '<cmd>lua require("kubectl").toggle()<cr>', { n
 
 You can also override the plugin's keymaps using the `<Plug>` mappings:
 
+<details><summary>Default Mappings</summary>
+
 ```lua
 -- default mappings
-vim.keymap.set("n", "<Plug>(kubectl.alias_view)", "<C-a>")
-vim.keymap.set("n", "<Plug>(kubectl.browse)", "gx")
-vim.keymap.set("n", "<Plug>(kubectl.contexts_view)", "<C-x>")
-vim.keymap.set("n", "<Plug>(kubectl.cordon)", "gC")
-vim.keymap.set("n", "<Plug>(kubectl.create_job)", "gc")
-vim.keymap.set("n", "<Plug>(kubectl.delete)", "gD")
-vim.keymap.set("n", "<Plug>(kubectl.describe)", "gd")
-vim.keymap.set("n", "<Plug>(kubectl.drain)", "gR")
-vim.keymap.set("n", "<Plug>(kubectl.edit)", "ge")
-vim.keymap.set("n", "<Plug>(kubectl.filter_label)", "<C-l>")
-vim.keymap.set("n", "<Plug>(kubectl.filter_view)", "<C-f>")
-vim.keymap.set("n", "<Plug>(kubectl.follow)", "f")
-vim.keymap.set("n", "<Plug>(kubectl.go_up)", "<BS>")
-vim.keymap.set("v", "<Plug>(kubectl.filter_term)", "<C-f>")
-vim.keymap.set("n", "<Plug>(kubectl.help)", "g?")
-vim.keymap.set("n", "<Plug>(kubectl.history)", "gh")
-vim.keymap.set("n", "<Plug>(kubectl.kill)", "gk")
-vim.keymap.set("n", "<Plug>(kubectl.logs)", "gl")
-vim.keymap.set("n", "<Plug>(kubectl.namespace_view)", "<C-n>")
-vim.keymap.set("n", "<Plug>(kubectl.portforward)", "gp")
-vim.keymap.set("n", "<Plug>(kubectl.portforwards_view)", "gP")
-vim.keymap.set("n", "<Plug>(kubectl.prefix)", "gp")
-vim.keymap.set("n", "<Plug>(kubectl.quit)", "")
-vim.keymap.set("n", "<Plug>(kubectl.refresh)", "gr")
-vim.keymap.set("n", "<Plug>(kubectl.rollout_restart)", "grr")
-vim.keymap.set("n", "<Plug>(kubectl.scale)", "gss")
-vim.keymap.set("n", "<Plug>(kubectl.select)", "<CR>")
-vim.keymap.set("n", "<Plug>(kubectl.set_image)", "gi")
-vim.keymap.set("n", "<Plug>(kubectl.sort)", "gs")
-vim.keymap.set("n", "<Plug>(kubectl.suspend_job)", "gx")
-vim.keymap.set("n", "<Plug>(kubectl.tab)", "<Tab>")
-vim.keymap.set("n", "<Plug>(kubectl.timestamps)", "gt")
-vim.keymap.set("n", "<Plug>(kubectl.top_nodes)", "gn")
-vim.keymap.set("n", "<Plug>(kubectl.top_pods)", "gp")
-vim.keymap.set("n", "<Plug>(kubectl.uncordon)", "gU")
-vim.keymap.set("n", "<Plug>(kubectl.view_1)", "1")
-vim.keymap.set("n", "<Plug>(kubectl.view_2)", "2")
-vim.keymap.set("n", "<Plug>(kubectl.view_3)", "3")
-vim.keymap.set("n", "<Plug>(kubectl.view_4)", "4")
-vim.keymap.set("n", "<Plug>(kubectl.view_5)", "5")
-vim.keymap.set("n", "<Plug>(kubectl.wrap)", "gw")
+vim.api.nvim_create_autocmd("FileType", {
+  group = group,
+  pattern = "k8s_*",
+  callback = function(ev)
+    local k = vim.keymap.set
+    local opts = { buffer = ev.buf }
+    k("n", "<Plug>(kubectl.alias_view)", "<C-a>", opts)
+    k("n", "<Plug>(kubectl.browse)", "gx", opts)
+    k("n", "<Plug>(kubectl.contexts_view)", "<C-x>", opts)
+    k("n", "<Plug>(kubectl.cordon)", "gC", opts)
+    k("n", "<Plug>(kubectl.create_job)", "gc", opts)
+    k("n", "<Plug>(kubectl.delete)", "gD", opts)
+    k("n", "<Plug>(kubectl.describe)", "gd", opts)
+    k("n", "<Plug>(kubectl.drain)", "gR", opts)
+    k("n", "<Plug>(kubectl.edit)", "ge", opts)
+    k("n", "<Plug>(kubectl.filter_label)", "<C-l>", opts)
+    k("n", "<Plug>(kubectl.filter_view)", "<C-f>", opts)
+    k("n", "<Plug>(kubectl.follow)", "f", opts)
+    k("n", "<Plug>(kubectl.go_up)", "<BS>", opts)
+    k("v", "<Plug>(kubectl.filter_term)", "<C-f>", opts)
+    k("n", "<Plug>(kubectl.help)", "g?", opts)
+    k("n", "<Plug>(kubectl.history)", "gh", opts)
+    k("n", "<Plug>(kubectl.kill)", "gk", opts)
+    k("n", "<Plug>(kubectl.logs)", "gl", opts)
+    k("n", "<Plug>(kubectl.namespace_view)", "<C-n>", opts)
+    k("n", "<Plug>(kubectl.portforward)", "gp", opts)
+    k("n", "<Plug>(kubectl.portforwards_view)", "gP", opts)
+    k("n", "<Plug>(kubectl.prefix)", "gp", opts)
+    k("n", "<Plug>(kubectl.quit)", "", opts)
+    k("n", "<Plug>(kubectl.refresh)", "gr", opts)
+    k("n", "<Plug>(kubectl.rollout_restart)", "grr", opts)
+    k("n", "<Plug>(kubectl.scale)", "gss", opts)
+    k("n", "<Plug>(kubectl.select)", "<CR>", opts)
+    k("n", "<Plug>(kubectl.set_image)", "gi", opts)
+    k("n", "<Plug>(kubectl.sort)", "gs", opts)
+    k("n", "<Plug>(kubectl.suspend_job)", "gx", opts)
+    k("n", "<Plug>(kubectl.tab)", "<Tab>", opts)
+    k("n", "<Plug>(kubectl.timestamps)", "gt", opts)
+    k("n", "<Plug>(kubectl.top_nodes)", "gn", opts)
+    k("n", "<Plug>(kubectl.top_pods)", "gp", opts)
+    k("n", "<Plug>(kubectl.uncordon)", "gU", opts)
+    k("n", "<Plug>(kubectl.view_1)", "1", opts)
+    k("n", "<Plug>(kubectl.view_2)", "2", opts)
+    k("n", "<Plug>(kubectl.view_3)", "3", opts)
+    k("n", "<Plug>(kubectl.view_4)", "4", opts)
+    k("n", "<Plug>(kubectl.view_5)", "5", opts)
+    k("n", "<Plug>(kubectl.wrap)", "gw", opts)
+  end,
+})
 ```
+
+</details>
 
 ## ⚙️ Configuration
 
@@ -180,19 +192,43 @@ vim.keymap.set("n", "<Plug>(kubectl.wrap)", "gw")
 }
 ```
 
-## Performance
+## 🎨 Colors
+
+The plugin uses the following highlight groups:
+<details><summary>Highlight Groups</summary>
+
+| Name                | Default            | Color |
+|---------------------|--------------------|-------|
+| KubectlHeader       | `{ fg = "#569CD6" }` | <span style="color:#569CD6">█</span> |
+| KubectlWarning      | `{ fg = "#D19A66" }` | <span style="color:#D19A66">█</span> |
+| KubectlError        | `{ fg = "#D16969" }` | <span style="color:#D16969">█</span> |
+| KubectlInfo         | `{ fg = "#608B4E" }` | <span style="color:#608B4E">█</span> |
+| KubectlDebug        | `{ fg = "#DCDCAA" }` | <span style="color:#DCDCAA">█</span> |
+| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <span style="color:#4EC9B0">█</span> |
+| KubectlPending      | `{ fg = "#C586C0" }` | <span style="color:#C586C0">█</span> |
+| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <span style="color:#D4A5A5">█</span> |
+| KubectlExperimental | `{ fg = "#CE9178" }` | <span style="color:#CE9178">█</span> |
+| KubectlNote         | `{ fg = "#9CDCFE" }` | <span style="color:#9CDCFE">█</span> |
+| KubectlGray         | `{ fg = "#666666" }` | <span style="color:#666666">█</span> |
+| KubectlPselect      | `{ bg = "#3e4451" }` | <span style="background-color:#3e4451">█</span> |
+| KubectlPmatch       | `{ link = "KubectlWarning" }` | <span style="color:#D19A66">█</span> |
+| KubectlUnderline    | `{ underline = true }` | - |
+
+</details>
+
+## 🚀 Performance
 
 ### Startup
 
 The setup function only adds ~1ms to startup.
 We use kubectl proxy and curl to reduce latency.
 
-## Versioning
+## ⚠️ Versioning
 
 > [!WARNING]
 > As we have not yet reached v1.0.0, we may have some breaking changes
 > in cases where it is deemed necessary.
 
-## Motivation
+## 💪🏼 Motivation
 
 This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for file browsing.

--- a/README.md
+++ b/README.md
@@ -199,19 +199,19 @@ The plugin uses the following highlight groups:
 
 | Name                | Default            | Color |
 |---------------------|--------------------|-------|
-| KubectlHeader       | `{ fg = "#569CD6" }` | <div style="width: 20px; height: 20px; background-color: #569CD6;"></div> |
-| KubectlWarning      | `{ fg = "#D19A66" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> @sample.svg |
-| KubectlError        | `{ fg = "#D16969" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D16969" /></svg> @sample.svg |
-| KubectlInfo         | `{ fg = "#608B4E" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#608B4E" /></svg> @sample.svg |
-| KubectlDebug        | `{ fg = "#DCDCAA" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#DCDCAA" /></svg> @sample.svg |
-| KubectlSuccess      | `{ fg = "#4EC9B0" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#4EC9B0" /></svg> @sample.svg |
-| KubectlPending      | `{ fg = "#C586C0" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#C586C0" /></svg> @sample.svg |
-| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D4A5A5" /></svg> @sample.svg |
-| KubectlExperimental | `{ fg = "#CE9178" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#CE9178" /></svg> @sample.svg |
-| KubectlNote         | `{ fg = "#9CDCFE" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#9CDCFE" /></svg> @sample.svg |
-| KubectlGray         | `{ fg = "#666666" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#666666" /></svg> @sample.svg |
-| KubectlPselect      | `{ bg = "#3e4451" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#3e4451" /></svg> @sample.svg |
-| KubectlPmatch       | `{ link = "KubectlWarning" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> |
+| KubectlHeader       | `{ fg = "#569CD6" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
+| KubectlWarning      | `{ fg = "#D19A66" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |
+| KubectlError        | `{ fg = "#D16969" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D16969" width="20" /> |
+| KubectlInfo         | `{ fg = "#608B4E" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=608B4E" width="20" /> |
+| KubectlDebug        | `{ fg = "#DCDCAA" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=DCDCAA" width="20" /> |
+| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=4EC9B0" width="20" /> |
+| KubectlPending      | `{ fg = "#C586C0" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
+| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D4A5A5" width="20" /> |
+| KubectlExperimental | `{ fg = "#CE9178" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=CE9178" width="20" /> |
+| KubectlNote         | `{ fg = "#9CDCFE" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=9CDCFE" width="20" /> |
+| KubectlGray         | `{ fg = "#666666" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=666666" width="20" /> |
+| KubectlPselect      | `{ bg = "#3e4451" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=3e4451" width="20" /> |
+| KubectlPmatch       | `{ link = "KubectlWarning" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |
 | KubectlUnderline    | `{ underline = true }` | - |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -199,23 +199,20 @@ The plugin uses the following highlight groups:
 
 | Name                | Default            | Color |
 |---------------------|--------------------|-------|
-| KubectlHeader       | `{ fg = "#569CD6" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#569CD6" /></svg> |
-| KubectlWarning      | `{ fg = "#D19A66" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> |
-| KubectlError        | `{ fg = "#D16969" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D16969" /></svg> |
-| KubectlInfo         | `{ fg = "#608B4E" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#608B4E" /></svg> |
-| KubectlDebug        | `{ fg = "#DCDCAA" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#DCDCAA" /></svg> |
-| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#4EC9B0" /></svg> |
-| KubectlPending      | `{ fg = "#C586C0" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#C586C0" /></svg> |
-| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D4A5A5" /></svg> |
-| KubectlExperimental | `{ fg = "#CE9178" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#CE9178" /></svg> |
-| KubectlNote         | `{ fg = "#9CDCFE" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#9CDCFE" /></svg> |
-| KubectlGray         | `{ fg = "#666666" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#666666" /></svg> |
-| KubectlPselect      | `{ bg = "#3e4451" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#3e4451" /></svg> |
+| KubectlHeader       | `{ fg = "#569CD6" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#569CD6" /></svg> @sample.svg |
+| KubectlWarning      | `{ fg = "#D19A66" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> @sample.svg |
+| KubectlError        | `{ fg = "#D16969" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D16969" /></svg> @sample.svg |
+| KubectlInfo         | `{ fg = "#608B4E" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#608B4E" /></svg> @sample.svg |
+| KubectlDebug        | `{ fg = "#DCDCAA" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#DCDCAA" /></svg> @sample.svg |
+| KubectlSuccess      | `{ fg = "#4EC9B0" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#4EC9B0" /></svg> @sample.svg |
+| KubectlPending      | `{ fg = "#C586C0" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#C586C0" /></svg> @sample.svg |
+| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D4A5A5" /></svg> @sample.svg |
+| KubectlExperimental | `{ fg = "#CE9178" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#CE9178" /></svg> @sample.svg |
+| KubectlNote         | `{ fg = "#9CDCFE" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#9CDCFE" /></svg> @sample.svg |
+| KubectlGray         | `{ fg = "#666666" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#666666" /></svg> @sample.svg |
+| KubectlPselect      | `{ bg = "#3e4451" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#3e4451" /></svg> @sample.svg |
 | KubectlPmatch       | `{ link = "KubectlWarning" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> |
 | KubectlUnderline    | `{ underline = true }` | - |
-
-
-There is not much need for $textsf{color[rgb]{1.0, 0.0, 0.0}SVG}$ images when you can just use $textsf{color[rgb]{0.0, 1.0, 0.0}inline code}$ to create coloured text.
 
 </details>
 
@@ -235,23 +232,3 @@ We use kubectl proxy and curl to reduce latency.
 ## 💪🏼 Motivation
 
 This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for file browsing.
-
-<!-- ![alt text](https://fwtbbmf399.execute-api.us-east-1.amazonaws.com/Prod/svg?source=https://raw.githubusercontent.com/vitalibo/markdown-inline-svg/master/readme.md&name=sample.svg) -->
-<!---->
-<!-- <details> -->
-<!-- <summary>SVG code</summary> -->
-<!---->
-<!-- ``` -->
-@sample.svg
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="121px" height="81px" viewBox="-0.5 -0.5 121 81" style="background-color: rgb(255, 255, 255);">
-    <defs/>
-    <g>
-        <ellipse cx="60" cy="40" rx="60" ry="40" fill="#ffffff" stroke="#000000" pointer-events="all"/>
-    </g>
-</svg>
-@sample.svg
-<!-- ``` -->
-
-</details>

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The plugin uses the following highlight groups:
 
 <details><summary>Highlight Groups</summary>
 
-| Name                | Default                       | Color                                                                                     |
+| Name                | Default                       | Color |
 | ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
 | KubectlHeader       | `{ fg = "#569CD6" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
 | KubectlWarning      | `{ fg = "#D19A66" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Processes kubectl outputs to enable vim-like navigation in a buffer for your clu
 
 ## ⚡️ Optional Dependencies
 
-- [kubediff](https://github.com/Ramilito/kubediff) or [DirDiff](https://github.com/will133/vim-dirdiff) (If you want to use the diff feature)
+- [kubediff](https://github.com/Ramilito/kubediff) or
+  [DirDiff](https://github.com/will133/vim-dirdiff) (If you want to use the diff
+  feature)
 
 ## 📦 Installation
 
@@ -97,6 +99,7 @@ You can also override the plugin's keymaps using the `<Plug>` mappings:
 
 ```lua
 -- default mappings
+local group = vim.api.nvim_create_augroup("kubectl_mappings", { clear = false })
 vim.api.nvim_create_autocmd("FileType", {
   group = group,
   pattern = "k8s_*",
@@ -195,24 +198,25 @@ vim.api.nvim_create_autocmd("FileType", {
 ## 🎨 Colors
 
 The plugin uses the following highlight groups:
+
 <details><summary>Highlight Groups</summary>
 
-| Name                | Default            | Color |
-|---------------------|--------------------|-------|
-| KubectlHeader       | `{ fg = "#569CD6" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
-| KubectlWarning      | `{ fg = "#D19A66" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |
-| KubectlError        | `{ fg = "#D16969" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D16969" width="20" /> |
-| KubectlInfo         | `{ fg = "#608B4E" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=608B4E" width="20" /> |
-| KubectlDebug        | `{ fg = "#DCDCAA" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=DCDCAA" width="20" /> |
-| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=4EC9B0" width="20" /> |
-| KubectlPending      | `{ fg = "#C586C0" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
-| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D4A5A5" width="20" /> |
-| KubectlExperimental | `{ fg = "#CE9178" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=CE9178" width="20" /> |
-| KubectlNote         | `{ fg = "#9CDCFE" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=9CDCFE" width="20" /> |
-| KubectlGray         | `{ fg = "#666666" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=666666" width="20" /> |
-| KubectlPselect      | `{ bg = "#3e4451" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=3e4451" width="20" /> |
+| Name                | Default                       | Color                                                                                     |
+| ------------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
+| KubectlHeader       | `{ fg = "#569CD6" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
+| KubectlWarning      | `{ fg = "#D19A66" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |
+| KubectlError        | `{ fg = "#D16969" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D16969" width="20" /> |
+| KubectlInfo         | `{ fg = "#608B4E" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=608B4E" width="20" /> |
+| KubectlDebug        | `{ fg = "#DCDCAA" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=DCDCAA" width="20" /> |
+| KubectlSuccess      | `{ fg = "#4EC9B0" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=4EC9B0" width="20" /> |
+| KubectlPending      | `{ fg = "#C586C0" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=C586C0" width="20" /> |
+| KubectlDeprecated   | `{ fg = "#D4A5A5" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D4A5A5" width="20" /> |
+| KubectlExperimental | `{ fg = "#CE9178" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=CE9178" width="20" /> |
+| KubectlNote         | `{ fg = "#9CDCFE" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=9CDCFE" width="20" /> |
+| KubectlGray         | `{ fg = "#666666" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=666666" width="20" /> |
+| KubectlPselect      | `{ bg = "#3e4451" }`          | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=3e4451" width="20" /> |
 | KubectlPmatch       | `{ link = "KubectlWarning" }` | <img src="https://www.thecolorapi.com/id?format=svg&named=false&hex=D19A66" width="20" /> |
-| KubectlUnderline    | `{ underline = true }` | - |
+| KubectlUnderline    | `{ underline = true }`        | -                                                                                         |
 
 </details>
 
@@ -231,4 +235,5 @@ We use kubectl proxy and curl to reduce latency.
 
 ## 💪🏼 Motivation
 
-This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for file browsing.
+This plugins main purpose is to browse the kubernetes state using vim like
+navigation and keys, similar to oil.nvim for file browsing.

--- a/README.md
+++ b/README.md
@@ -199,20 +199,23 @@ The plugin uses the following highlight groups:
 
 | Name                | Default            | Color |
 |---------------------|--------------------|-------|
-| KubectlHeader       | `{ fg = "#569CD6" }` | <span style="color:#569CD6">█</span> |
-| KubectlWarning      | `{ fg = "#D19A66" }` | <span style="color:#D19A66">█</span> |
-| KubectlError        | `{ fg = "#D16969" }` | <span style="color:#D16969">█</span> |
-| KubectlInfo         | `{ fg = "#608B4E" }` | <span style="color:#608B4E">█</span> |
-| KubectlDebug        | `{ fg = "#DCDCAA" }` | <span style="color:#DCDCAA">█</span> |
-| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <span style="color:#4EC9B0">█</span> |
-| KubectlPending      | `{ fg = "#C586C0" }` | <span style="color:#C586C0">█</span> |
-| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <span style="color:#D4A5A5">█</span> |
-| KubectlExperimental | `{ fg = "#CE9178" }` | <span style="color:#CE9178">█</span> |
-| KubectlNote         | `{ fg = "#9CDCFE" }` | <span style="color:#9CDCFE">█</span> |
-| KubectlGray         | `{ fg = "#666666" }` | <span style="color:#666666">█</span> |
-| KubectlPselect      | `{ bg = "#3e4451" }` | <span style="background-color:#3e4451">█</span> |
-| KubectlPmatch       | `{ link = "KubectlWarning" }` | <span style="color:#D19A66">█</span> |
+| KubectlHeader       | `{ fg = "#569CD6" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#569CD6" /></svg> |
+| KubectlWarning      | `{ fg = "#D19A66" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> |
+| KubectlError        | `{ fg = "#D16969" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D16969" /></svg> |
+| KubectlInfo         | `{ fg = "#608B4E" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#608B4E" /></svg> |
+| KubectlDebug        | `{ fg = "#DCDCAA" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#DCDCAA" /></svg> |
+| KubectlSuccess      | `{ fg = "#4EC9B0" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#4EC9B0" /></svg> |
+| KubectlPending      | `{ fg = "#C586C0" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#C586C0" /></svg> |
+| KubectlDeprecated   | `{ fg = "#D4A5A5" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D4A5A5" /></svg> |
+| KubectlExperimental | `{ fg = "#CE9178" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#CE9178" /></svg> |
+| KubectlNote         | `{ fg = "#9CDCFE" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#9CDCFE" /></svg> |
+| KubectlGray         | `{ fg = "#666666" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#666666" /></svg> |
+| KubectlPselect      | `{ bg = "#3e4451" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#3e4451" /></svg> |
+| KubectlPmatch       | `{ link = "KubectlWarning" }` | <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> |
 | KubectlUnderline    | `{ underline = true }` | - |
+
+
+There is not much need for $textsf{color[rgb]{1.0, 0.0, 0.0}SVG}$ images when you can just use $textsf{color[rgb]{0.0, 1.0, 0.0}inline code}$ to create coloured text.
 
 </details>
 
@@ -232,3 +235,23 @@ We use kubectl proxy and curl to reduce latency.
 ## 💪🏼 Motivation
 
 This plugins main purpose is to browse the kubernetes state using vim like navigation and keys, similar to oil.nvim for file browsing.
+
+<!-- ![alt text](https://fwtbbmf399.execute-api.us-east-1.amazonaws.com/Prod/svg?source=https://raw.githubusercontent.com/vitalibo/markdown-inline-svg/master/readme.md&name=sample.svg) -->
+<!---->
+<!-- <details> -->
+<!-- <summary>SVG code</summary> -->
+<!---->
+<!-- ``` -->
+@sample.svg
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="121px" height="81px" viewBox="-0.5 -0.5 121 81" style="background-color: rgb(255, 255, 255);">
+    <defs/>
+    <g>
+        <ellipse cx="60" cy="40" rx="60" ry="40" fill="#ffffff" stroke="#000000" pointer-events="all"/>
+    </g>
+</svg>
+@sample.svg
+<!-- ``` -->
+
+</details>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kubectl.nvim
 
 Processes kubectl outputs to enable vim-like navigation in a buffer for your cluster.
+
 <img src="https://github.com/user-attachments/assets/3c070dc5-1b93-47a0-9412-bf34ae611267" width="1700px">
 
 ## ✨ Features

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The plugin uses the following highlight groups:
 
 | Name                | Default            | Color |
 |---------------------|--------------------|-------|
-| KubectlHeader       | `{ fg = "#569CD6" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#569CD6" /></svg> @sample.svg |
+| KubectlHeader       | `{ fg = "#569CD6" }` | <div style="width: 20px; height: 20px; background-color: #569CD6;"></div> |
 | KubectlWarning      | `{ fg = "#D19A66" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D19A66" /></svg> @sample.svg |
 | KubectlError        | `{ fg = "#D16969" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#D16969" /></svg> @sample.svg |
 | KubectlInfo         | `{ fg = "#608B4E" }` | @sample.svg <svg width="20" height="20"><rect width="20" height="20" fill="#608B4E" /></svg> @sample.svg |

--- a/lua/kubectl/actions/highlight.lua
+++ b/lua/kubectl/actions/highlight.lua
@@ -17,6 +17,7 @@ M.symbols = {
   clear = "KubectlClear",
   tab = "KubectlTab",
   underline = "KubectlUnderline",
+  match = "KubectlPmatch",
 }
 
 local highlights = {
@@ -31,7 +32,8 @@ local highlights = {
   KubectlExperimental = { fg = "#CE9178" }, -- Brown
   KubectlNote = { fg = "#9CDCFE" }, -- Light Blue
   KubectlGray = { fg = "#666666" }, -- Dark Gray
-  KubectlPum = { bg = "#3e4451" },
+  KubectlPselect = { bg = "#3e4451" },
+  KubectlPmatch = { link = "KubectlWarning" },
   KubectlUnderline = { underline = true },
 }
 

--- a/lua/kubectl/utils/completion.lua
+++ b/lua/kubectl/utils/completion.lua
@@ -53,7 +53,7 @@ local function open_completion_pum(items, selected_index, search_term)
 
   -- Enable cursorline and define custom highlight for cursorline
   vim.api.nvim_set_option_value("cursorline", cursorline_enabled, { win = M.pum_win })
-  vim.api.nvim_set_option_value("winhl", "CursorLine:KubectlPum", { win = M.pum_win })
+  vim.api.nvim_set_option_value("winhl", "CursorLine:KubectlPselect,Search:None", { win = M.pum_win })
   vim.api.nvim_set_option_value("bufhidden", "wipe", { scope = "local" })
   -- Clear the buffer
   vim.api.nvim_buf_set_lines(M.pum_buf, 0, -1, false, {})
@@ -68,7 +68,7 @@ local function open_completion_pum(items, selected_index, search_term)
     local s = fzy.positions(search_term:lower(), item:lower())
     if s then
       for _, e in pairs(s) do
-        vim.api.nvim_buf_add_highlight(M.pum_buf, -1, hl.symbols.warning, i - 1, e - 1, e)
+        vim.api.nvim_buf_add_highlight(M.pum_buf, -1, hl.symbols.match, i - 1, e - 1, e)
       end
     end
   end


### PR DESCRIPTION
- better document how to override a keymap, since the keymaps are buffer local
- add option to override pum matches (the orange letters marking the search letters)
- document highlights