### PR TITLE
chore/separate-top-pods-nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ vim.api.nvim_create_autocmd("FileType", {
     k("n", "<Plug>(kubectl.view_pv)", "", opts) -- PersistentVolumes view
     k("n", "<Plug>(kubectl.view_pvc)", "", opts) -- PersistentVolumeClaims view
     k("n", "<Plug>(kubectl.view_sa)", "", opts) -- ServiceAccounts view
-    k("n", "<Plug>(kubectl.view_top)", "", opts) -- Top view
+    k("n", "<Plug>(kubectl.view_top_nodes)", "", opts) -- Top view for nodes
+    k("n", "<Plug>(kubectl.view_top_pods)", "", opts) -- Top view for pods
 
     -- Deployment/DaemonSet actions
     k("n", "<Plug>(kubectl.rollout_restart)", "grr", opts) -- Rollout restart

--- a/ftplugin/k8s_top_nodes.lua
+++ b/ftplugin/k8s_top_nodes.lua
@@ -1,7 +1,7 @@
 local api = vim.api
 local loop = require("kubectl.utils.loop")
 local mappings = require("kubectl.mappings")
-local pods_top_view = require("kubectl.views.top-pods")
+local nodes_top_view = require("kubectl.views.top-nodes")
 
 --- Set key mappings for the buffer
 local function set_keymaps(bufnr)
@@ -10,7 +10,8 @@ local function set_keymaps(bufnr)
     silent = true,
     desc = "Top pods",
     callback = function()
-      pods_top_view.View()
+      local top_view = require("kubectl.views.top-pods")
+      top_view.View()
     end,
   })
 
@@ -19,8 +20,8 @@ local function set_keymaps(bufnr)
     silent = true,
     desc = "Top nodes",
     callback = function()
-      local top_view = require("kubectl.views.top-nodes")
-      top_view.View()
+      nodes_top_view.View()
+      top_def.res_type = "nodes"
     end,
   })
 end
@@ -29,7 +30,7 @@ end
 local function init()
   set_keymaps(0)
   if not loop.is_running() then
-    loop.start_loop(pods_top_view.View)
+    loop.start_loop(nodes_top_view.View)
   end
 end
 

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -75,14 +75,14 @@ function M.setup(options)
     elseif action == "apply" then
       completion.apply()
     elseif action == "top" then
-      local top_view = require("kubectl.views.top")
-      local top_def = require("kubectl.views.top.definition")
+      local top_view
       if #opts.fargs == 2 then
-        top_view.View()
-        top_def.res_type = opts.fargs[2]
+        local top_type = opts.fargs[2]
+        top_view = require("kubectl.views.top-" .. top_type)
       else
-        top_view.View()
+        top_view = require("kubectl.views.top-pods")
       end
+      top_view.View()
     elseif action == "api-resources" then
       require("kubectl.views.api-resources").View()
     else

--- a/lua/kubectl/utils/viewsTable.lua
+++ b/lua/kubectl/utils/viewsTable.lua
@@ -20,7 +20,8 @@ return {
   pv = { "persistentvolumes", "persistentvolume", "pv" },
   pvc = { "persistentvolumeclaims", "persistentvolumeclaim", "pvc" },
   clusterrolebinding = { "clusterrolebindings", "clusterrolebinding", "clusterrolebindings.rbac.authorization.k8s.io" },
-  top = { "top", "top.pods", "top.nodes" },
+  ["top-nodes"] = { "top-nodes" },
+  ["top-pods"] = { "top-pods" },
   ingresses = { "ingresses", "ingress" },
   helm = { "helm" },
 }

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -91,7 +91,8 @@ function M.Hints(headers)
     { key = "<Plug>(kubectl.view_pv)", desc = "PersistentVolumes" },
     { key = "<Plug>(kubectl.view_pvc)", desc = "PersistentVolumeClaims" },
     { key = "<Plug>(kubectl.view_sa)", desc = "ServiceAccounts" },
-    { key = "<Plug>(kubectl.view_top)", desc = "Top" },
+    { key = "<Plug>(kubectl.view_top_nodes)", desc = "Top Nodes" },
+    { key = "<Plug>(kubectl.view_top_pods)", desc = "Top Pods" },
   }
 
   local global_keymaps = tables.get_plug_mappings(globals, "n")

--- a/lua/kubectl/views/top-nodes/definition.lua
+++ b/lua/kubectl/views/top-nodes/definition.lua
@@ -1,0 +1,25 @@
+local M = {
+  resource = "top-nodes",
+  display_name = "top nodes",
+  ft = "k8s_top_nodes",
+  url = { "{{BASE}}/apis/metrics.k8s.io/v1beta1/nodes?pretty=false" },
+  hints = {
+    { key = "<Plug>(kubectl.top_pods)", desc = "top-pods", long_desc = "Top pods" },
+    { key = "<Plug>(kubectl.top_nodes)", desc = "top-nodes", long_desc = "Top nodes" },
+  },
+  nodes = {},
+}
+
+function M.getHeaders()
+  local headers = {
+    "NAME",
+    "CPU-CORES",
+    "CPU-%",
+    "MEM-BYTES",
+    "MEM-%",
+  }
+
+  return headers
+end
+
+return vim.tbl_extend("force", require("kubectl.views.top.definition"), M)

--- a/lua/kubectl/views/top-nodes/init.lua
+++ b/lua/kubectl/views/top-nodes/init.lua
@@ -1,0 +1,20 @@
+local ResourceBuilder = require("kubectl.resourcebuilder")
+local definition = require("kubectl.views.top-nodes.definition")
+local tables = require("kubectl.utils.tables")
+local top_definition = require("kubectl.views.top.definition")
+
+local M = {}
+
+function M.View(cancellationToken)
+  definition.get_nodes()
+  top_definition.res_type = "nodes"
+  ResourceBuilder:view(definition, cancellationToken, { informer = false })
+end
+
+--- Get current seletion for view
+---@return string|nil
+function M.getCurrentSelection()
+  return tables.getCurrentSelection(1)
+end
+
+return M

--- a/lua/kubectl/views/top-pods/definition.lua
+++ b/lua/kubectl/views/top-pods/definition.lua
@@ -1,0 +1,23 @@
+local M = {
+  resource = "top-pods",
+  display_name = "top pods",
+  ft = "k8s_top_pods",
+  url = { "{{BASE}}/apis/metrics.k8s.io/v1beta1/{{NAMESPACE}}pods?pretty=false" },
+  hints = {
+    { key = "<Plug>(kubectl.top_pods)", desc = "top-pods", long_desc = "Top pods" },
+    { key = "<Plug>(kubectl.top_nodes)", desc = "top-nodes", long_desc = "Top nodes" },
+  },
+}
+
+function M.getHeaders()
+  local headers = {
+    "NAMESPACE",
+    "NAME",
+    "CPU-CORES",
+    "MEM-BYTES",
+  }
+
+  return headers
+end
+
+return vim.tbl_extend("force", require("kubectl.views.top.definition"), M)

--- a/lua/kubectl/views/top-pods/init.lua
+++ b/lua/kubectl/views/top-pods/init.lua
@@ -1,17 +1,11 @@
 local ResourceBuilder = require("kubectl.resourcebuilder")
-local definition = require("kubectl.views.top.definition")
+local definition = require("kubectl.views.top-pods.definition")
 local tables = require("kubectl.utils.tables")
 
 local M = {}
 
 function M.View(cancellationToken)
-  definition.url = definition.urls[definition.res_type]
-  definition.display_name = "top " .. definition.res_type
-
   ResourceBuilder:view(definition, cancellationToken, { informer = false })
-  if definition.res_type == "nodes" then
-    definition.get_nodes()
-  end
 end
 
 --- Get current seletion for view

--- a/lua/kubectl/views/top/definition.lua
+++ b/lua/kubectl/views/top/definition.lua
@@ -1,21 +1,5 @@
-local M = {
-  resource = "top",
-  display_name = "top",
-  ft = "k8s_top",
-  url = {},
-  urls = {
-    pods = { "{{BASE}}/apis/metrics.k8s.io/v1beta1/{{NAMESPACE}}pods?pretty=false" },
-    nodes = { "{{BASE}}/apis/metrics.k8s.io/v1beta1/nodes?pretty=false" },
-  },
-  res_type = "pods",
-  hints = {
-    { key = "<Plug>(kubectl.top_pods)", desc = "top-pods", long_desc = "Top pods" },
-    { key = "<Plug>(kubectl.top_nodes)", desc = "top-nodes", long_desc = "Top nodes" },
-  },
-  nodes = {},
-}
-
 local hl = require("kubectl.actions.highlight")
+local M = { res_type = "pods", nodes = {} }
 
 function M.getHl(percent)
   local symbol
@@ -29,21 +13,21 @@ function M.getHl(percent)
   return symbol
 end
 
-local function split_num_unit(mem)
+function M.split_num_unit(mem)
   local num = tonumber(string.sub(mem, 1, -3)) or 0
   local unit = string.sub(mem, -2) or "Ki"
   return num, unit
 end
 
-local function get_ki_val(mem)
-  local mem_val, unit = split_num_unit(mem)
+function M.get_ki_val(mem)
+  local mem_val, unit = M.split_num_unit(mem)
   if unit == "Mi" then
     mem_val = math.floor(mem_val * 1024)
   end
   return mem_val
 end
 
-local function kib_to_mib_or_gib(mem)
+function M.kib_to_mib_or_gib(mem)
   local final_val = math.floor(mem / 1024)
   local unit = "Mi"
   if final_val > 10240 then
@@ -104,7 +88,7 @@ function M.getMemUsage(row)
   if row.containers then
     for _, container in pairs(row.containers) do
       local mem = container.usage.memory
-      temp_val = temp_val + get_ki_val(mem)
+      temp_val = temp_val + M.get_ki_val(mem)
     end
   elseif row.usage.memory then
     local mem = row.usage.memory
@@ -112,7 +96,7 @@ function M.getMemUsage(row)
   end
 
   status.sort_by = temp_val
-  local final_val, unit = kib_to_mib_or_gib(temp_val)
+  local final_val, unit = M.kib_to_mib_or_gib(temp_val)
   status.value = final_val .. unit
   return status
 end
@@ -122,10 +106,10 @@ function M.getMemPercent(row, node)
   if not row or not row.usage or not row.usage.memory then
     return status
   end
-  local mem = get_ki_val(row.usage.memory)
+  local mem = M.get_ki_val(row.usage.memory)
   local out_of = node and node.status and node.status.capacity.memory or ""
   if out_of ~= "" then
-    local total = get_ki_val(out_of)
+    local total = M.get_ki_val(out_of)
     local percent = math.ceil((mem / total) * 100)
     status.value = percent .. "%"
     status.symbol = M.getHl(percent)
@@ -152,7 +136,7 @@ function M.processRow(rows)
         end
       end
     end
-    local pod = {
+    local res = {
       namespace = row.metadata.namespace,
       name = row.metadata.name,
       ["cpu-cores"] = M.getCpuUsage(row),
@@ -161,7 +145,7 @@ function M.processRow(rows)
       ["mem-%"] = M.getMemPercent(row, node_details),
     }
 
-    table.insert(data, pod)
+    table.insert(data, res)
   end
   return data
 end
@@ -191,8 +175,7 @@ function M.get_nodes()
   ResourceBuilder:new("nodes"):setCmd(nodes_def.url, "curl"):fetchAsync(function(self)
     self:decodeJson()
     M.nodes = self.data.items
-    --
-    ----
   end)
 end
+
 return M


### PR DESCRIPTION
Separate nodes view from pods view
mainly to be able to see `top pods` from the alias menu