### PR TITLE
chore/label-filter-removes-filter

### DIFF
--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -83,6 +83,7 @@ function M.filter_label()
     end
 
     -- display view
+    state.setFilter("")
     definition.url = new_args
     view.configure_definition = false
     view.View()


### PR DESCRIPTION
When filtering by label, remove the regular filter, same as 3495404a