### PR TITLE
feat/negative-and-multi-filter

### DIFF
--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -76,23 +76,42 @@ function M.filter(tbl, predicate)
   return result
 end
 
---- Filter lines in an array based on a pattern starting from a given index
+--- Filter lines in an array based on multiple patterns starting from a given index
 ---@param array table[]
----@param pattern string
+---@param patterns string
 ---@param startAt number
 ---@return table[]
-function M.filter_line(array, pattern, startAt)
-  if not pattern or pattern == "" then
+function M.filter_line(array, patterns, startAt)
+  if not patterns or patterns == "" then
     return array
   end
 
   startAt = startAt or 1
   local filtered_array = {}
+  local pattern_list = {}
+
+  -- Split the patterns by comma
+  for pattern in patterns:gmatch("[^,]+") do
+    table.insert(pattern_list, pattern)
+  end
 
   -- Filter the array starting from startAt
   for index = startAt, #array do
     local line = array[index]
-    if M.is_in_table(line, pattern) then
+    local all_match = true
+
+    for _, pattern in ipairs(pattern_list) do
+      local is_negative = pattern:sub(1, 1) == "!"
+      local actual_pattern = is_negative and pattern:sub(2) or pattern
+      local match = M.is_in_table(line, actual_pattern)
+
+      if (is_negative and match) or (not is_negative and not match) then
+        all_match = false
+        break
+      end
+    end
+
+    if all_match then
       table.insert(filtered_array, line)
     end
   end

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -107,7 +107,6 @@ function M.filter_line(array, patterns, startAt)
 
       if (is_negative and match) or (not is_negative and not match) then
         all_match = false
-        break
       end
     end
 

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -109,7 +109,7 @@ end
 ---@param hints table[]
 ---@param marks table[]
 local function addHeaderRow(headers, hints, marks)
-  local hint_line = "Hint: "
+  local hint_line = "Hints: "
   local length = #hint_line
   M.add_mark(marks, #hints, 0, length, hl.symbols.success)
 

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -124,6 +124,13 @@ function M.filter()
     { key = "<Plug>(kubectl.quit)", desc = "close" },
   }, false, false)
 
+  -- Add textual hints
+  local header_len = #header
+  table.insert(header, header_len - 1, "Use commas to separate multiple patterns.")
+  table.insert(header, header_len - 1, "Prefix a pattern with ! for negative filtering.")
+  table.insert(header, header_len - 1, "All patterns must match for a line to be included.")
+  marks[#marks].row = #header - 1
+
   table.insert(header, "History:")
   local headers_len = #header
   for _, value in ipairs(state.filter_history) do


### PR DESCRIPTION
since I would not expect to find a comma `,` or an exclamation sign `!` I used them as the tokens
negative search with `!`
multiple searches concatenated by a comma
![2024-09-29_19-18-38 (1)](https://github.com/user-attachments/assets/94d5b61f-f351-48ac-9227-178c4939b510)

also look at the gif @Ramilito 
you can see that the hints are not populated in the first time I open filter float, only on the second time we can see the hints.

I guess this issue would not leave us alone.