### PR TITLE
feat/save-state-on-context-switch

### DIFF
--- a/ftplugin/k8s_pvc.lua
+++ b/ftplugin/k8s_pvc.lua
@@ -1,6 +1,5 @@
 local loop = require("kubectl.utils.loop")
 local pvc_view = require("kubectl.views.pvc")
-local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
 
 --- Set key mappings for the buffer
@@ -17,7 +16,7 @@ local function set_keymaps(bufnr)
       end
 
       -- get pv of pvc
-
+      local state = require("kubectl.state")
       local resource = tables.find_resource(state.instance.data, name, ns)
       if not resource then
         return
@@ -25,7 +24,7 @@ local function set_keymaps(bufnr)
       local pv_name = resource.spec.volumeName
 
       -- add to filter and view
-      require("kubectl.state").filter = pv_name
+      state.setFilter(pv_name)
       pv_view.View()
     end,
   })

--- a/lua/kubectl/views/contexts/init.lua
+++ b/lua/kubectl/views/contexts/init.lua
@@ -62,15 +62,16 @@ end
 --- Change context and restart proxy
 --- @param cmd string
 function M.change_context(cmd)
+  local state = require("kubectl.state")
   local results = commands.shell_command("kubectl", { "config", "use-context", cmd })
 
   if not results then
     vim.notify(results, vim.log.levels.INFO)
   end
+  state.set_session()
   kube.stop_kubectl_proxy()
   kube.start_kubectl_proxy(function()
     local view = require("kubectl.views")
-    local state = require("kubectl.state")
     view.LoadFallbackData(true)
     state.setup()
   end)


### PR DESCRIPTION
Currently when switching between contexts, the current session's filter history is gone and the config is loaded again.

when we change context we need to save the state to the file