### PR TITLE
chore/pod-container-count

### DIFF
--- a/lua/kubectl/views/pods/definition.lua
+++ b/lua/kubectl/views/pods/definition.lua
@@ -17,11 +17,13 @@ local M = {
 
 local function getReady(row)
   local status = { symbol = "", value = "", sort_by = 0 }
-  local readyCount = 0
   local containers = 0
+  if row.spec and row.spec.containers then
+    containers = #row.spec.containers
+  end
+  local readyCount = 0
   if row.status and row.status.containerStatuses then
     for _, value in ipairs(row.status.containerStatuses) do
-      containers = containers + 1
       if value.ready then
         readyCount = readyCount + 1
       end


### PR DESCRIPTION
we calculate the number of containers from the `row.status` but if the pod was evicted, we won't get any `containerStatuses` which makes the pod's READY column to be `0/0` thus being colored blue which is good when in fact it's not.

Better to calculate the number of containers from `row.spec`