### PR TITLE
feat/add-close-keymaps

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -3,6 +3,22 @@ local state = require("kubectl.state")
 local api = vim.api
 local M = {}
 
+local function close_keymaps(buf, change_modified)
+  local keymaps = {
+    { "n", "q" },
+    { "n", "<esc>" },
+    { "i", "<C-c>" },
+  }
+  for _, map in ipairs(keymaps) do
+    vim.keymap.set(map[1], map[2], function()
+      if change_modified then
+        api.nvim_set_option_value("modified", false, { buf = buf })
+      end
+      vim.cmd.close()
+    end, { buffer = buf, silent = true })
+  end
+end
+
 --- Creates a buffer with a given name and type.
 --- @param bufname string: The name of the buffer.
 --- @param buftype string|nil: The type of the buffer (optional).
@@ -101,10 +117,7 @@ function M.aliases_buffer(filetype, callback, opts)
 
   if not buf then
     buf = create_buffer(bufname, "prompt")
-    vim.keymap.set("n", "q", function()
-      api.nvim_set_option_value("modified", false, { buf = buf })
-      vim.cmd.close()
-    end, { buffer = buf, silent = true })
+    close_keymaps(buf, true)
   end
 
   local win = layout.float_dynamic_layout(buf, filetype, opts.title)
@@ -132,10 +145,7 @@ function M.filter_buffer(filetype, callback, opts)
 
   if not buf then
     buf = create_buffer(bufname, "prompt")
-    vim.keymap.set("n", "q", function()
-      api.nvim_set_option_value("modified", false, { buf = buf })
-      vim.cmd.close()
-    end, { buffer = buf, silent = true })
+    close_keymaps(buf, true)
   end
 
   local win = layout.float_dynamic_layout(buf, filetype, opts.title or "")
@@ -193,7 +203,7 @@ function M.confirmation_buffer(prompt, filetype, onConfirm, opts)
       vim.api.nvim_win_close(win, true)
     end,
   })
-  vim.keymap.set("n", "q", vim.cmd.close, { buffer = buf, silent = true })
+  close_keymaps(buf, false)
 
   layout.set_buf_options(buf, filetype, opts.syntax or filetype, bufname)
   layout.set_win_options(win)
@@ -223,10 +233,7 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
     else
       buf = create_buffer(bufname)
     end
-    vim.keymap.set("n", "q", function()
-      api.nvim_set_option_value("modified", false, { buf = buf })
-      vim.cmd.close()
-    end, { buffer = buf, silent = true })
+    close_keymaps(buf, true)
   end
 
   local win = layout.float_dynamic_layout(buf, opts.syntax or filetype, title or "")


### PR DESCRIPTION
add mappings to close a float buffer
<kbd>ctrl-c</kbd> on insert mode
<kbd>q</kbd> and <kbd>ESC</kbd> on normal mode

I really feel those are defaults and we can avoid letting it being changed.