### PR TITLE
fix: unload event on winclose

### DIFF
--- a/lua/kubectl/actions/eventhandler.lua
+++ b/lua/kubectl/actions/eventhandler.lua
@@ -18,7 +18,7 @@ function EventHandler:on(event, buf_nr, callback)
 
   handler_instance.listeners[event][buf_nr] = callback
 
-  vim.api.nvim_create_autocmd({ "BufDelete" }, {
+  vim.api.nvim_create_autocmd({ "WinClosed", "BufDelete" }, {
     buffer = buf_nr,
     callback = function()
       EventHandler:off(event, buf_nr)


### PR DESCRIPTION
Events weren't being removed from eventhandler causing the buffer to be updated on new events even though we closed the buffer.