### PR TITLE
chore: misc doc updates and remove unused `exact` param from is_in_table

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -16,6 +16,9 @@ local function create_buffer(bufname, buftype)
   return buf
 end
 
+--- Gets buffer number by name
+--- @param bufname string: The name of the buffer
+--- @return integer|nil: The buffer number
 local function get_buffer_by_name(bufname)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     local name = vim.api.nvim_buf_get_name(buf)
@@ -121,6 +124,7 @@ end
 
 --- Creates a filter buffer.
 --- @param filetype string: The filetype of the buffer.
+--- @param callback function: The callback function.
 --- @param opts { title: string|nil, header: { data: table }}: Options for the buffer.
 function M.filter_buffer(filetype, callback, opts)
   local bufname = "kubectl_filter"
@@ -202,6 +206,7 @@ end
 --- Creates a namespace buffer.
 --- @param filetype string: The filetype of the buffer.
 --- @param title string|nil: The filetype of the buffer.
+--- @param callback function: The callback function.
 --- @param opts { header: { data: table }, prompt: boolean, syntax: string}|nil: Options for the buffer.
 function M.floating_dynamic_buffer(filetype, title, callback, opts)
   opts = opts or {}
@@ -236,6 +241,7 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
   return buf
 end
 
+--- Sets buffer content.
 --- @param buf number: Buffer number
 --- @param opts { content: table, marks: table,  header: { data: table }}
 function M.set_content(buf, opts)

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -206,7 +206,7 @@ end
 --- Creates a namespace buffer.
 --- @param filetype string: The filetype of the buffer.
 --- @param title string|nil: The filetype of the buffer.
---- @param callback function: The callback function.
+--- @param callback function|nil: The callback function.
 --- @param opts { header: { data: table }, prompt: boolean, syntax: string}|nil: Options for the buffer.
 function M.floating_dynamic_buffer(filetype, title, callback, opts)
   opts = opts or {}
@@ -229,7 +229,9 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
       vim.cmd.close()
       vim.api.nvim_input("<Plug>(kubectl.refresh)")
 
-      callback(input)
+      if callback ~= nil then
+          callback(input)
+      end
     end)
 
     vim.cmd("startinsert")

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -120,7 +120,7 @@ end
 --- Execute a shell command asynchronously
 --- @param cmd string The command to execute
 --- @param args string[] The arguments for the command
---- @param on_exit? function The callback function to execute when the command exits
+--- @param on_exit? function The callback function to execute when the command exits (optional)
 --- @param on_stdout? function The callback function to execute when there is stdout output (optional)
 --- @param on_stderr? function The callback function to execute when there is stderr output (optional)
 --- @param opts { env: table, stdin: string, detach: boolean, timeout: number }|nil The arguments for the command
@@ -189,6 +189,7 @@ end
 --- NOTE: Don't use this for kubectl calls since this doesn't support clear_env
 --- @param cmd string The command to execute
 --- @param args string|string[] The arguments for the command
+--- @param opts { env: table, stdin: string, on_stdout: string, detach: boolean, timeout: number }|nil The arguments for the command
 function M.execute_terminal(cmd, args, opts)
   opts = opts or {}
   local command = M.configure_command(cmd, opts.env, args)

--- a/lua/kubectl/actions/highlight.lua
+++ b/lua/kubectl/actions/highlight.lua
@@ -32,7 +32,7 @@ local highlights = {
   KubectlExperimental = { fg = "#CE9178" }, -- Brown
   KubectlNote = { fg = "#9CDCFE" }, -- Light Blue
   KubectlGray = { fg = "#666666" }, -- Dark Gray
-  KubectlPselect = { bg = "#3e4451" },
+  KubectlPselect = { bg = "#3e4451" }, -- Grey Blue
   KubectlPmatch = { link = "KubectlWarning" },
   KubectlUnderline = { underline = true },
 }

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -40,7 +40,7 @@ function M.start_kubectl_proxy(callback)
   local handle = vim.system(command.args, {
     clear_env = true,
     env = command.env,
-    stdin = false,
+    stdin = nil,
     stderr = function(_, data)
       vim.schedule(function()
         if data then

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -40,7 +40,6 @@ function M.start_kubectl_proxy(callback)
   local handle = vim.system(command.args, {
     clear_env = true,
     env = command.env,
-    stdin = nil,
     stderr = function(_, data)
       vim.schedule(function()
         if data then

--- a/lua/kubectl/actions/kube.lua
+++ b/lua/kubectl/actions/kube.lua
@@ -40,6 +40,7 @@ function M.start_kubectl_proxy(callback)
   local handle = vim.system(command.args, {
     clear_env = true,
     env = command.env,
+    stdin = false,
     stderr = function(_, data)
       vim.schedule(function()
         if data then

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -130,7 +130,11 @@ function M.get_editor_dimensions()
   return width, height
 end
 
-function M.win_size_fit_content(buf_nr, offset)
+--- Fits content to window size
+--- @param buf_nr integer: The buffer number.
+--- @param height_offset integer: The height offset.
+--- @return vim.api.keyset.win_config
+function M.win_size_fit_content(buf_nr, height_offset)
   local win_id = vim.api.nvim_get_current_win()
   local win_config = vim.api.nvim_win_get_config(win_id)
 
@@ -146,10 +150,10 @@ function M.win_size_fit_content(buf_nr, offset)
     end
   end
 
-  win_config.height = rows + offset
+  win_config.height = rows + height_offset
   win_config.width = max_columns
 
-  api.nvim_set_option_value("scrolloff", rows + offset, { win = win_id })
+  api.nvim_set_option_value("scrolloff", rows + height_offset, { win = win_id })
   vim.api.nvim_win_set_config(win_id, win_config)
   return win_config
 end

--- a/lua/kubectl/actions/layout.lua
+++ b/lua/kubectl/actions/layout.lua
@@ -133,7 +133,7 @@ end
 --- Fits content to window size
 --- @param buf_nr integer: The buffer number.
 --- @param height_offset integer: The height offset.
---- @return vim.api.keyset.win_config
+--- @return { height: number, width: number }
 function M.win_size_fit_content(buf_nr, height_offset)
   local win_id = vim.api.nvim_get_current_win()
   local win_config = vim.api.nvim_win_get_config(win_id)

--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -63,7 +63,7 @@ end
 ---@param syntax? string The syntax to use for the floating window
 ---@return ResourceBuilder
 function ResourceBuilder:displayFloatFit(filetype, title, syntax)
-  self.buf_nr = buffers.floating_dynamic_buffer(filetype, title, false, { syntax })
+  self.buf_nr = buffers.floating_dynamic_buffer(filetype, title, nil, { syntax })
 
   return self
 end

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -34,7 +34,7 @@ function M.is_in_table(tbl, str, exact)
   local lowered_str = str:lower()
   for _, value in pairs(tbl) do
     if type(value) == "table" then
-      if M.is_in_table(value, str, exact) then
+      if M.is_in_table(value, str, false) then
         return true
       end
     end
@@ -106,7 +106,7 @@ function M.filter_line(array, patterns, startAt)
     for _, pattern in ipairs(pattern_list) do
       local is_negative = pattern:sub(1, 1) == "!"
       local actual_pattern = is_negative and pattern:sub(2) or pattern
-      local match = M.is_in_table(line, actual_pattern)
+      local match = M.is_in_table(line, actual_pattern, false)
 
       if (is_negative and match) or (not is_negative and not match) then
         all_match = false

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -24,8 +24,9 @@ end
 --- Check if a string is in a table, recursively
 ---@param tbl table
 ---@param str string
+---@param exact boolean
 ---@return boolean
-function M.is_in_table(tbl, str)
+function M.is_in_table(tbl, str, exact)
   if str == nil then
     return false
   end
@@ -33,10 +34,13 @@ function M.is_in_table(tbl, str)
   local lowered_str = str:lower()
   for _, value in pairs(tbl) do
     if type(value) == "table" then
-      if M.is_in_table(value, str) then
+      if M.is_in_table(value, str, exact) then
         return true
       end
-    elseif tostring(value):lower():find(lowered_str, 1, true) then
+    end
+    if exact and tostring(value):lower() == lowered_str then
+      return true
+    elseif not exact and tostring(value):lower():find(lowered_str, 1, true) then
       return true
     end
   end

--- a/lua/kubectl/utils/find.lua
+++ b/lua/kubectl/utils/find.lua
@@ -25,7 +25,7 @@ end
 ---@param tbl table
 ---@param str string
 ---@return boolean
-function M.is_in_table(tbl, str, exact)
+function M.is_in_table(tbl, str)
   if str == nil then
     return false
   end
@@ -36,10 +36,7 @@ function M.is_in_table(tbl, str, exact)
       if M.is_in_table(value, str) then
         return true
       end
-    end
-    if exact and tostring(value):lower() == lowered_str then
-      return true
-    elseif not exact and tostring(value):lower():find(lowered_str, 1, true) then
+    elseif tostring(value):lower():find(lowered_str, 1, true) then
       return true
     end
   end
@@ -65,7 +62,9 @@ function M.single(tbl, keys, value)
   return nil
 end
 
--- @type function(tbl: table, predicate: function): table
+---@param tbl table
+---@param predicate table
+---@return table
 function M.filter(tbl, predicate)
   local result = {}
   for _, v in ipairs(tbl) do

--- a/lua/kubectl/utils/grid.lua
+++ b/lua/kubectl/utils/grid.lua
@@ -1,4 +1,3 @@
-local config = require("kubectl.config")
 local hl = require("kubectl.actions.highlight")
 local M = {}
 

--- a/lua/kubectl/utils/loop.lua
+++ b/lua/kubectl/utils/loop.lua
@@ -7,7 +7,7 @@ local active_sessions = {}
 --- Start a loop for a specific buffer
 ---@param buf number
 ---@param callback fun(is_cancelled: fun(): boolean)
----@param opts? table
+---@param opts? { interval: number }: The arguments for the loop.
 function M.start_loop_for_buffer(buf, callback, opts)
   if timers[buf] then
     return
@@ -56,7 +56,7 @@ function M.start_loop_for_buffer(buf, callback, opts)
 end
 
 --- Stop the loop for a specific buffer
----@param buf number
+---@param buf number: The buffer number.
 function M.stop_loop_for_buffer(buf)
   local timer = timers[buf]
   if timer then

--- a/lua/kubectl/utils/string.lua
+++ b/lua/kubectl/utils/string.lua
@@ -1,9 +1,12 @@
 local M = {}
 
+---@param str string
 function M.capitalize(str)
   return str:sub(1, 1):upper() .. str:sub(2)
 end
 
+---@param buf number The buffer number.
+---@param char string The divider.
 function M.divider(buf, char)
   if not char then
     char = "-"
@@ -14,6 +17,8 @@ function M.divider(buf, char)
   vim.api.nvim_win_set_cursor(0, { line_count + 1, 0 })
 end
 
+--- Gets the text from the current visual selection
+---@return string
 function M.get_visual_selection()
   local esc = vim.api.nvim_replace_termcodes("<esc>", true, false, true)
   vim.api.nvim_feedkeys(esc, "x", false)

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -3,7 +3,6 @@ local hl = require("kubectl.actions.highlight")
 local state = require("kubectl.state")
 local time = require("kubectl.utils.time")
 local M = {}
-local context_rows = {}
 
 --- Calculate column widths for table data
 ---@param rows table[]

--- a/lua/kubectl/utils/tables.lua
+++ b/lua/kubectl/utils/tables.lua
@@ -3,6 +3,7 @@ local hl = require("kubectl.actions.highlight")
 local state = require("kubectl.state")
 local time = require("kubectl.utils.time")
 local M = {}
+local context_rows = {}
 
 --- Calculate column widths for table data
 ---@param rows table[]
@@ -23,6 +24,9 @@ local function calculate_column_widths(rows, columns)
   return widths
 end
 
+--- Calculate and distribute extra padding
+---@param widths table The table of current column widths
+---@param headers string[] The column headers
 local function calculate_extra_padding(widths, headers)
   local win = vim.api.nvim_get_current_win()
   local win_width = vim.api.nvim_win_get_width(win)
@@ -72,6 +76,9 @@ local function calculate_extra_padding(widths, headers)
   end
 end
 
+--- Gets both global and buffer-local plug keymaps for the given mode
+--- @param headers table[] The header table
+--- @param mode string The VIM mode
 function M.get_plug_mappings(headers, mode)
   local keymaps_table = {}
   local header_lookup = {}
@@ -131,6 +138,9 @@ local function addHeaderRow(headers, hints, marks)
   table.insert(hints, hint_line .. "\n")
 end
 
+--- Adds the heartbeat element
+---@param hints table The keymap hints
+---@param marks table The extmarks
 local function addHeartbeat(hints, marks)
   local padding = "   "
   if state.livez.ok then
@@ -218,8 +228,8 @@ end
 
 --- Add divider row
 ---@param divider { resource: string, count: string, filter: string }|nil
----@param hints table[]
----@param marks table[]
+---@param hints table The keymap hints
+---@param marks table The extmarks
 local function addDividerRow(divider, hints, marks)
   -- Add separator row
   local win = vim.api.nvim_get_current_win()
@@ -274,11 +284,11 @@ local function addDividerRow(divider, hints, marks)
 end
 
 --- Generate header hints and marks
----@param headers table[]
+---@param headers table
 ---@param include_defaults boolean
 ---@param include_context boolean
 ---@param divider { resource: string, count: string, filter: string }|nil
----@return table[], table[]
+---@return table, table
 function M.generateHeader(headers, include_defaults, include_context, divider)
   local hints = {}
   local marks = {}
@@ -361,7 +371,7 @@ end
 --- Pretty print data in a table format
 ---@param data table[]
 ---@param headers string[]
----@return table[], table[]
+---@return table, table
 function M.pretty_print(data, headers, sort_by)
   if headers == nil or data == nil then
     return {}, {}

--- a/lua/kubectl/utils/time.lua
+++ b/lua/kubectl/utils/time.lua
@@ -5,7 +5,7 @@ local M = {}
 local obj_fresh = config.options.obj_fresh
 local success_symbol = hl.symbols.success
 
---- get a string representation of the time difference between two timestamps
+--- Get a string representation of the time difference between two timestamps
 ---@param timeA number more recent timestamp
 ---@param timeB number older timestamp
 ---@return string diff_str

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -9,7 +9,7 @@ local views = require("kubectl.views")
 local M = {}
 
 --- Saves filter history
---- @param input string[]: The input
+--- @param input string: The input
 function M.save_history(input)
   local state = require("kubectl.state")
   local history = state.filter_history

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -8,6 +8,8 @@ local views = require("kubectl.views")
 
 local M = {}
 
+--- Saves filter history
+--- @param input string[]: The input
 function M.save_history(input)
   local state = require("kubectl.state")
   local history = state.filter_history

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -131,7 +131,7 @@ function M.Hints(headers)
     tables.add_mark(marks, start_row + index - 1, 0, #header.key, hl.symbols.pending)
   end
 
-  local buf = buffers.floating_dynamic_buffer("k8s_hints", "Hints", false)
+  local buf = buffers.floating_dynamic_buffer("k8s_hints", "Hints", nil)
 
   local content = vim.split(table.concat(hints, ""), "\n")
   buffers.set_content(buf, { content = content, marks = marks })

--- a/lua/kubectl/views/overview/init.lua
+++ b/lua/kubectl/views/overview/init.lua
@@ -34,7 +34,6 @@ function M.View(cancellationToken)
     if cmd.cmd == "curl" then
       cmd.args = url.build(cmd.args)
       cmd.args = url.addHeaders(cmd.args, cmd.contentType)
-    else
     end
   end
 


### PR DESCRIPTION
- Misc function doc updates & fixes as I read through code
- Code change:`lua/kubectl/utils/find.lua` is_in_table() removed unused `exact` param
- Code change: Set `stdin` param of `vim.system` call to nil instead of false - suggested by LSP (May be wrong?)