### PR TITLE
fix: add check for str in capitalize func

### DIFF
--- a/lua/kubectl/utils/string.lua
+++ b/lua/kubectl/utils/string.lua
@@ -2,7 +2,11 @@ local M = {}
 
 ---@param str string
 function M.capitalize(str)
-  return str:sub(1, 1):upper() .. str:sub(2)
+    if str and #str > 0 then
+        return str:sub(1, 1):upper() .. str:sub(2)
+    else
+        return str
+    end
 end
 
 ---@param buf number The buffer number.


### PR DESCRIPTION
**Description**

Fixes error when an empty string is passed to string util `capitalize` function.

**Reproduction**

This will occur when:

1. Go to a container view of a pod
2. `C-F` to filter
3. Press enter without entering in filter text

`lua/kubectl/mappings.lua`
```
pcall(view[string_utils.capitalize(resource[2])], resource[3] or "", resource[4] or "")
```

This call to `capitalize` will pass `resource[3] or ""`.  `resource[3]` will not be present so "" is passed as an argument.

**Error**

```
Error  11:50:54 msg_show.emsg E5108: Error executing lua: ...ttain/Personal/kubectl.nvim/lua/kubectl/utils/string.lua:5: attempt to index local 'str' (a nil value)
stack traceback:
	...ttain/Personal/kubectl.nvim/lua/kubectl/utils/string.lua:5: in function 'capitalize'
	...lbrittain/Personal/kubectl.nvim/lua/kubectl/mappings.lua:166: in function <...lbrittain/Personal/kubectl.nvim/lua/kubectl/mappings.lua:139>
```

PS:
1. I'd have added a test as a habit, but there are none. I checked telescope and fugitive and there aren't unit tests really. I guess this is normal for plugins? I did some googling around and found that [plenary.nvim](https://github.com/nvim-lua/plenary.nvim/blob/master/TESTS_README.md) has a testing framework.
2. Filtering containers isn't working for me, but I don't know why yet. For example, when I have a list of containers and one has the name "foo", when I enter "foo" into the filter I expect all other containers to be filtered out. But all containers are still visible.