### PR TITLE
fix: dont display global hints on floats

### DIFF
--- a/lua/kubectl/resourcebuilder.lua
+++ b/lua/kubectl/resourcebuilder.lua
@@ -312,7 +312,7 @@ function ResourceBuilder:view_float(definition, opts)
           :process(self.definition.processRow, true)
           :sort()
           :prettyPrint(self.definition.getHeaders)
-          :addHints(self.definition.hints, true, false, false)
+          :addHints(self.definition.hints, false, false, false)
           :setContent()
       else
         builder:splitData()


### PR DESCRIPTION
Fixes discussion in #447 