### PR TITLE
docs: overwrite default keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can also override the plugin's keymaps using the `<Plug>` mappings:
 
 ```lua
 -- default mappings
-local group = vim.api.nvim_create_augroup("kubectl_mappings", { clear = false })
+local group = vim.api.nvim_create_augroup("kubectl_mappings", { clear = true })
 vim.api.nvim_create_autocmd("FileType", {
   group = group,
   pattern = "k8s_*",


### PR DESCRIPTION
When user(me) wants to overwrite the default keymaps and copied the snippets from the README doc,
I found it doesn't work.

So I think to change the `clean` to `true` may help users like me.

By the way, I really don't like the `<C-l>` default keymap since many people use it to navigate between windows.

Maybe use `<localleader>l` is a better idea?