### PR TITLE
fix: set empty string as default

### DIFF
--- a/ftplugin/k8s_pods.lua
+++ b/ftplugin/k8s_pods.lua
@@ -116,8 +116,7 @@ local function set_keymaps(bufnr)
 
       vim.schedule(function()
         if next(data) == nil then
-          api.nvim_err_writeln("No container ports exposed in pod")
-          return
+          data[1] = { port = { value = "" } }
         end
 
         local win_config


### PR DESCRIPTION
fixes: #496

This just takes care of the immediate issue, it should be better when using the new #485 