### PR TITLE
fix: set highlights as default

### DIFF
--- a/lua/kubectl/actions/highlight.lua
+++ b/lua/kubectl/actions/highlight.lua
@@ -56,6 +56,7 @@ function M.setup()
   for group, attrs in pairs(highlights) do
     local success, hl = pcall(api.nvim_get_hl, 0, group)
     if not success or not hl then
+      attrs.default = true
       api.nvim_set_hl(0, group, attrs)
     end
   end


### PR DESCRIPTION
Setting the highlight as default allows color schemes to override them without depending on order of loading