### PR TITLE
feat: added terminal_cmd to config, if set, exec in terminal and not a buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ For overriding the default mappings when using `lazy.nvim` [check out our wiki p
     bin = "kubediff" -- or any other binary
   },
   kubectl_cmd = { cmd = "kubectl", env = {}, args = {}, persist_context_change = false },
+  terminal_cmd = nil, -- Exec will launch in a terminal if set, i.e. "ghostty -e"
   namespace = "All",
   namespace_fallback = {}, -- If you have limited access you can list all the namespaces here
   hints = true,

--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -23,7 +23,7 @@ function M.configure_command(cmd, envs, args)
     if state.context["current-context"] then
       table.insert(result.args, "--context")
       table.insert(result.args, state.context["current-context"])
-      vim.print(result.args)
+      -- vim.print(result.args)
     end
   end
 

--- a/lua/kubectl/config.lua
+++ b/lua/kubectl/config.lua
@@ -3,6 +3,7 @@ local M = {}
 ---@class KubectlOptions
 ---@field log_level number
 ---@field auto_refresh { enabled: boolean, interval: number }
+---@field terminal_cmd string?
 ---@field namespace string
 ---@field namespace_fallback string[]
 ---@field headers boolean
@@ -29,6 +30,7 @@ local defaults = {
   -- NOTE: Some executions using the io.open and vim.fn.terminal will still have default shell environments,
   -- in that case, the environments below will not override the defaults and should not be in your .zshrc/.bashrc files
   kubectl_cmd = { cmd = "kubectl", env = {}, args = {}, persist_context_change = false },
+  terminal_cmd = nil, -- Exec will launch in a terminal if set, i.e. "ghostty -e"
   namespace = "All",
   namespace_fallback = {},
   headers = true,

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -22,14 +22,15 @@ function M.View(pod, ns)
 end
 
 function M.exec(pod, ns)
+  local args = { "exec", "-it", pod, "-n", ns, "-c ", M.selection, "--", "/bin/sh" }
   local cmd = "kubectl"
-  local args = string.format("exec -it %s -n %s -c %s -- /bin/sh", pod, ns, M.selection)
 
   if config.options.terminal_cmd then
-    vim.fn.jobstart(config.options.terminal_cmd .. " " .. cmd .. " " .. args)
+    local command = commands.configure_command(cmd, {}, args)
+    vim.fn.jobstart(config.options.terminal_cmd .. " " .. table.concat(command.args, " "))
   else
     buffers.floating_buffer("k8s_container_exec", "ssh " .. M.selection)
-    commands.execute_terminal(cmd, vim.split(args, " "))
+    commands.execute_terminal(cmd, args)
   end
 end
 

--- a/lua/kubectl/views/containers/init.lua
+++ b/lua/kubectl/views/containers/init.lua
@@ -22,8 +22,15 @@ function M.View(pod, ns)
 end
 
 function M.exec(pod, ns)
-  buffers.floating_buffer("k8s_container_exec", "ssh " .. M.selection)
-  commands.execute_terminal("kubectl", { "exec", "-it", pod, "-n", ns, "-c ", M.selection, "--", "/bin/sh" })
+  local cmd = "kubectl"
+  local args = string.format("exec -it %s -n %s -c %s -- /bin/sh", pod, ns, M.selection)
+
+  if config.options.terminal_cmd then
+    vim.fn.jobstart(config.options.terminal_cmd .. " " .. cmd .. " " .. args)
+  else
+    buffers.floating_buffer("k8s_container_exec", "ssh " .. M.selection)
+    commands.execute_terminal(cmd, vim.split(args, " "))
+  end
 end
 
 function M.debug(pod, ns)


### PR DESCRIPTION
Added terminal_cmd to config, if set, will exec in a standalone terminal of your choice, rather than a buffer.