### PR TITLE
fix: narrow down the close when binding floats

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -115,7 +115,7 @@ function M.aliases_buffer(filetype, callback, opts)
     callback(input)
     vim.cmd("stopinsert")
     api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.close()
+    vim.cmd.fclose()
   end)
 
   vim.cmd("startinsert")
@@ -149,7 +149,7 @@ function M.filter_buffer(filetype, callback, opts)
     end
 
     api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.close()
+    vim.cmd.fclose()
     vim.api.nvim_input("<Plug>(kubectl.refresh)")
   end)
 
@@ -230,7 +230,7 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
   if opts.prompt then
     vim.fn.prompt_setcallback(buf, function(input)
       api.nvim_set_option_value("modified", false, { buf = buf })
-      vim.cmd.close()
+      vim.cmd.fclose()
       vim.api.nvim_input("<Plug>(kubectl.refresh)")
 
       if callback ~= nil then

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -193,7 +193,7 @@ function M.PortForwards()
 
   vim.keymap.set("n", "q", function()
     vim.api.nvim_set_option_value("modified", false, { buf = self.buf_nr })
-    vim.cmd.close()
+    vim.cmd.fclose()
     vim.api.nvim_input("<Plug>(kubectl.refresh)")
   end, { buffer = self.buf_nr, silent = true })
 end

--- a/lua/kubectl/views/lineage/init.lua
+++ b/lua/kubectl/views/lineage/init.lua
@@ -100,7 +100,7 @@ function M.set_keymaps(bufnr)
       local kind, name, ns = M.getCurrentSelection()
       if name and ns then
         vim.api.nvim_set_option_value("modified", false, { buf = 0 })
-        vim.cmd.close()
+        vim.cmd.fclose()
 
         view.view_or_fallback(kind)
       else


### PR DESCRIPTION
Use fclose instead of close to close floating windows. This avoids the problem (not sure if there is any yet) of accidentally closing the main window.