### PR TITLE
fix: save session when entering instead on leave

### DIFF
--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -27,7 +27,6 @@ function M.close()
 
   if win_config.relative == "" then
     local kube = require("kubectl.actions.kube")
-    state.set_session()
     state.stop_livez()
     kube.stop_kubectl_proxy()()
     informer.stop()
@@ -44,8 +43,6 @@ function M.toggle(opts)
   else
     if opts.tab then
       vim.cmd("tabnew")
-      local tab = vim.api.nvim_get_current_tabpage()
-      vim.api.nvim_tabpage_set_var(tab, "title", "kubectl_tab")
     end
     M.open()
     M.is_open = true
@@ -60,7 +57,17 @@ function M.setup(options)
   local config = require("kubectl.config")
   config.setup(options)
   state.setNS(config.options.namespace)
-  mappings.setup()
+
+  local group = vim.api.nvim_create_augroup("Kubectl", { clear = true })
+  vim.api.nvim_create_autocmd("FileType", {
+    group = group,
+    pattern = "k8s_*",
+    callback = function(ev)
+      mappings.setup(ev)
+			vim.print(ev)
+      state.set_session(ev)
+    end,
+  })
 
   vim.api.nvim_create_user_command("Kubectl", function(opts)
     local action = opts.fargs[1]
@@ -117,21 +124,4 @@ function M.setup(options)
   })
 end
 
-vim.api.nvim_create_autocmd({ "VimLeavePre", "TabClosed" }, {
-  callback = function(args)
-    if args.event == "VimLeavePre" then
-      state.set_session()
-      return
-    end
-
-    local tab = tonumber(args.match)
-
-    if tab then
-      local ok, id = pcall(vim.api.nvim_tabpage_get_var, tab, "title")
-      if ok and id == "kubectl_tab" then
-        state.set_session()
-      end
-    end
-  end,
-})
 return M

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -64,7 +64,6 @@ function M.setup(options)
     pattern = "k8s_*",
     callback = function(ev)
       mappings.setup(ev)
-			vim.print(ev)
       state.set_session(ev)
     end,
   })

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -528,36 +528,29 @@ function M.register()
   end
 end
 
-function M.setup()
-  local group = vim.api.nvim_create_augroup("Kubectl", { clear = true })
-  vim.api.nvim_create_autocmd("FileType", {
-    group = group,
-    pattern = "k8s_*",
-    callback = function(ev)
-      local view_name = ev.match:gsub("k8s_", "")
-      local ok, view_mappings = pcall(require, "kubectl.views." .. view_name .. ".mappings")
+function M.setup(ev)
+  local view_name = ev.match:gsub("k8s_", "")
+  local ok, view_mappings = pcall(require, "kubectl.views." .. view_name .. ".mappings")
 
-      local globals = M.get_mappings()
-      local locals = {}
-      if ok and view_mappings.overrides then
-        locals = view_mappings.overrides
-      end
+  local globals = M.get_mappings()
+  local locals = {}
+  if ok and view_mappings.overrides then
+    locals = view_mappings.overrides
+  end
 
-      local all_mappings = vim.tbl_deep_extend("force", globals, locals)
-      for lhs, def in pairs(all_mappings) do
-        vim.keymap.set(def.mode or "n", lhs, def.callback, {
-          desc = def.desc,
-          noremap = def.noremap ~= false,
-          silent = def.silent ~= false,
-          buffer = true,
-        })
-      end
+  local all_mappings = vim.tbl_deep_extend("force", globals, locals)
+  for lhs, def in pairs(all_mappings) do
+    vim.keymap.set(def.mode or "n", lhs, def.callback, {
+      desc = def.desc,
+      noremap = def.noremap ~= false,
+      silent = def.silent ~= false,
+      buffer = true,
+    })
+  end
 
-      if ok then
-        pcall(view_mappings.register)
-      end
-      M.register()
-    end,
-  })
+  if ok then
+    pcall(view_mappings.register)
+  end
+  M.register()
 end
 return M

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -217,9 +217,9 @@ function M.set_session(ev)
     local session_name = M.context["current-context"]
     M.session.contexts[session_name] = { view = ev.file, namespace = M.ns }
   end
-	M.session.filter_history = M.filter_history
-	M.session.alias_history = M.alias_history
-	commands.save_config("kubectl.json", M.session)
+  M.session.filter_history = M.filter_history
+  M.session.alias_history = M.alias_history
+  commands.save_config("kubectl.json", M.session)
 end
 
 function M.restore_session()

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -211,11 +211,15 @@ function M.addToHistory(new_view)
 end
 
 function M.set_session(ev)
-  local session_name = M.context["current-context"]
-  M.session.contexts[session_name] = { view = ev.file, namespace = M.ns }
-  M.session.filter_history = M.filter_history
-  M.session.alias_history = M.alias_history
-  commands.save_config("kubectl.json", M.session)
+  local win_config = vim.api.nvim_win_get_config(0)
+
+  if win_config.relative == "" then
+    local session_name = M.context["current-context"]
+    M.session.contexts[session_name] = { view = ev.file, namespace = M.ns }
+  end
+	M.session.filter_history = M.filter_history
+	M.session.alias_history = M.alias_history
+	commands.save_config("kubectl.json", M.session)
 end
 
 function M.restore_session()

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -210,12 +210,9 @@ function M.addToHistory(new_view)
   table.insert(M.history, new_view)
 end
 
-function M.set_session()
+function M.set_session(ev)
   local session_name = M.context["current-context"]
-  local ok, buf_name = pcall(vim.api.nvim_buf_get_var, 0, "buf_name")
-  if ok then
-    M.session.contexts[session_name] = { view = buf_name, namespace = M.ns }
-  end
+  M.session.contexts[session_name] = { view = ev.file, namespace = M.ns }
   M.session.filter_history = M.filter_history
   M.session.alias_history = M.alias_history
   commands.save_config("kubectl.json", M.session)

--- a/lua/kubectl/views/contexts/init.lua
+++ b/lua/kubectl/views/contexts/init.lua
@@ -72,7 +72,6 @@ function M.change_context(cmd)
     end
   end
   state.context["current-context"] = cmd
-  state.set_session()
   kube.stop_kubectl_proxy()
   kube.start_kubectl_proxy(function()
     local cache = require("kubectl.cache")

--- a/lua/kubectl/views/top_pods/definition.lua
+++ b/lua/kubectl/views/top_pods/definition.lua
@@ -1,5 +1,5 @@
 local M = {
-  resource = "top-pods",
+  resource = "top_pods",
   display_name = "top pods",
   ft = "k8s_top_pods",
   url = { "{{BASE}}/apis/metrics.k8s.io/v1beta1/{{NAMESPACE}}pods?pretty=false" },


### PR DESCRIPTION
Our current session management saves the session when leaving neovim.
When using new tab though, you would close just the plugin. TabClosed event is too late to look for a buf_name variable since the buffer is already closed.

Inverting the logic to save when we load the view is easier to handle and less complex solution overall.

This is ready but need to verify all the views