### PR TITLE
Fix/filter labels

### DIFF
--- a/lua/kubectl/views/filter_label/init.lua
+++ b/lua/kubectl/views/filter_label/init.lua
@@ -43,6 +43,7 @@ local function display_float(builder)
         end
         for _, label in ipairs(builder.fl_content.res_labels) do
           if label.is_label and label.is_selected then
+            table.insert(sess_labels, label.text)
             table.insert(confirmed_labels, label.text)
           end
         end

--- a/lua/kubectl/views/filter_label/utils.lua
+++ b/lua/kubectl/views/filter_label/utils.lua
@@ -12,12 +12,15 @@ function M.add_existing_labels(builder)
     extmarks = {},
   })
 
-  -- add existing labels from state
-  for _, label in ipairs(state.filter_label) do
-    local label_line = {
+  -- add existing labels from session
+  local sess_fl = state.getSessionFilterLabel()
+  for i, label in ipairs(sess_fl) do
+    -- check if label is in state.filter_label
+    table.insert(builder.fl_content.existing_labels, {
       is_label = true,
-      is_selected = true,
+      is_selected = false,
       text = label,
+      sess_filter_id = i,
       ---@type ExtMark[]
       extmarks = {
         {
@@ -27,20 +30,16 @@ function M.add_existing_labels(builder)
           right_gravity = false,
         },
       },
-    }
-    table.insert(builder.fl_content.existing_labels, label_line)
+    })
   end
 
-  -- add existing labels from session
-  local sess_fl = state.getSessionFilterLabel()
-  for i, label in ipairs(sess_fl) do
-    -- check if label is in state.filter_label
-    if not vim.tbl_contains(state.filter_label, label) then
-      local label_line = {
+  -- add existing labels from state
+  for _, label in ipairs(state.filter_label) do
+    if not vim.tbl_contains(sess_fl, label) then
+      table.insert(builder.fl_content.existing_labels, {
         is_label = true,
-        is_selected = false,
+        is_selected = true,
         text = label,
-        sess_filter_id = i,
         ---@type ExtMark[]
         extmarks = {
           {
@@ -50,8 +49,7 @@ function M.add_existing_labels(builder)
             right_gravity = false,
           },
         },
-      }
-      table.insert(builder.fl_content.existing_labels, label_line)
+      })
     end
   end
 


### PR DESCRIPTION
if a filter was added and it was under "Pod labels" for example, the next time the menu shows, we cannot edit this label since it doesn't have sess_filter_id

add the existing labels in a different order and preserve on confirm