### PR TITLE
feat/support-filter-key-fallback

### DIFF
--- a/kubectl-client/src/lib.rs
+++ b/kubectl-client/src/lib.rs
@@ -225,7 +225,7 @@ pub async fn get_fallback_table_async(lua: Lua, json: String) -> LuaResult<Strin
         args.sort_order,
         args.filter,
         args.filter_label,
-        None,
+        args.filter_key,
     )?;
 
     serde_json::to_string(&processed).map_err(|e| mlua::Error::RuntimeError(e.to_string()))

--- a/kubectl-client/src/structs.rs
+++ b/kubectl-client/src/structs.rs
@@ -80,6 +80,7 @@ pub struct GetFallbackTableArgs {
     pub sort_order: Option<String>,
     pub filter: Option<String>,
     pub filter_label: Option<Vec<String>>,
+    pub filter_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -61,6 +61,7 @@ function M.Draw(cancellationToken)
 
   local filter = state.getFilter()
   local filter_label = state.getFilterLabel()
+  local filter_key = state.getFilterKey()
   local sort_by = state.sortby[builder.definition.resource].current_word
   local sort_order = state.sortby[builder.definition.resource].order
 
@@ -71,6 +72,7 @@ function M.Draw(cancellationToken)
     sort_order = sort_order,
     filter = filter,
     filter_label = filter_label,
+    filter_key = filter_key,
   }, function(result)
     if not result then
       return


### PR DESCRIPTION
I'm creating some manual go-to-child functions and I noticed filter_key isn't passed to fallback on kube.rs
this PR adds the functonality.
works for me :)