### PR TITLE
fix: allow short names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,18 +930,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.7.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1280,22 +1274,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1471,7 +1455,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -1521,7 +1505,7 @@ dependencies = [
  "backon",
  "educe",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown",
  "hostname",
  "json-patch",
  "k8s-openapi",
@@ -1641,7 +1625,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1803,9 +1787,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1817,25 +1801,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
  "reqwest",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "futures-core",
  "http",
  "opentelemetry",
  "opentelemetry-http",
@@ -1851,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1863,28 +1845,26 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.0",
+ "rand",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -2112,34 +2092,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
  "zerocopy 0.8.23",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2149,16 +2108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -2307,7 +2257,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2696,7 +2646,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -3051,16 +3001,16 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3076,27 +3026,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3110,7 +3040,9 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -3212,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -3324,7 +3256,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.0",
+ "rand",
  "sha1",
  "thiserror 2.0.12",
  "utf-8",

--- a/kubectl-client/src/processors/fallback.rs
+++ b/kubectl-client/src/processors/fallback.rs
@@ -218,7 +218,6 @@ impl Processor for FallbackProcessor {
             } else {
                 vec!["NAME".into()]
             };
-            headers.push("AGE".into());
             headers.extend(cols.iter().map(|c| c.name.to_uppercase()));
 
             let headers_lua = lua.to_value(&headers)?;

--- a/kubectl-telemetry/Cargo.toml
+++ b/kubectl-telemetry/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 
 [dependencies]
 tokio                       = { version = "1", features = ["rt-multi-thread", "macros"] }
-tracing                     = { version = "0.1", features = ["log", "attributes"] }
+tracing                     = { version = "0.1.41", features = ["log", "attributes"] }
 tracing-subscriber          = { version = "0.3", features = ["env-filter", "fmt", "registry"] }
-tracing-opentelemetry       = "0.30"
+tracing-opentelemetry       = "0.31"
 tracing-appender            = "0.2"
-opentelemetry               = "0.29"
-opentelemetry_sdk           = { version = "0.29", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp          = { version = "0.29", features = ["trace", "grpc-tonic", "http-proto", "reqwest-client", "logs"] }
-opentelemetry-semantic-conventions = "0.29"
+opentelemetry               = "0.30"
+opentelemetry_sdk           = { version = "0.30", features = ["trace", "rt-tokio"] }
+opentelemetry-otlp          = { version = "0.30", features = ["trace", "grpc-tonic", "http-proto", "reqwest-client", "logs"] }
+opentelemetry-semantic-conventions = "0.30"

--- a/kubectl-telemetry/src/lib.rs
+++ b/kubectl-telemetry/src/lib.rs
@@ -69,7 +69,7 @@ pub fn setup_logger(
         .spawn(move || {
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
-                .worker_threads(1)
+                .worker_threads(4)
                 .build()
                 .expect("Tokio runtime");
 

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -129,7 +129,7 @@ function M.apply_marks(bufnr, marks, header)
           sign_text = mark.sign_text or nil,
           sign_hl_group = mark.sign_hl_group or nil,
         })
-				-- TODO: Extract column header management
+        -- TODO: Extract column header management
         -- the first row is always column headers, we save that so other content can use it
         if not is_float and ok and mark.row == 0 then
           state.content_row_start = start_row + 1

--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -78,8 +78,20 @@ function M.apply_marks(bufnr, marks, header)
   pcall(api.nvim_buf_clear_namespace, bufnr, ns_id, 0, -1)
   local local_marks = marks
   local local_header = header
-
   state.marks.ns_id = ns_id
+
+  local is_float = false
+  -- TODO: Extract column header management
+  local wins = vim.fn.win_findbuf(bufnr)
+  for _, win in ipairs(wins) do
+    local cfg = vim.api.nvim_win_get_config(win)
+    if cfg.relative ~= "" then
+      is_float = true
+    end
+  end
+  if not is_float then
+    state.marks.header = {}
+  end
 
   vim.schedule(function()
     if local_header and local_header.marks then
@@ -98,7 +110,6 @@ function M.apply_marks(bufnr, marks, header)
       end
     end
     if local_marks then
-      state.marks.header = {}
       for _, mark in ipairs(local_marks) do
         -- adjust for content not being at first row
         local start_row = mark.row
@@ -118,8 +129,9 @@ function M.apply_marks(bufnr, marks, header)
           sign_text = mark.sign_text or nil,
           sign_hl_group = mark.sign_hl_group or nil,
         })
+				-- TODO: Extract column header management
         -- the first row is always column headers, we save that so other content can use it
-        if ok and mark.row == 0 then
+        if not is_float and ok and mark.row == 0 then
           state.content_row_start = start_row + 1
           table.insert(state.marks.header, result)
         end

--- a/lua/kubectl/cache.lua
+++ b/lua/kubectl/cache.lua
@@ -18,7 +18,7 @@ end
 
 local function process_apis(resource, cached_api_resources)
   local name = string.lower(resource.crd_name)
-  cached_api_resources.values[name] = {
+  local value = {
     name = name,
     gvk = {
       g = resource.gvk.group,
@@ -31,18 +31,14 @@ local function process_apis(resource, cached_api_resources)
     api_version = resource.api_version,
   }
 
-  require("kubectl.state").sortby[name] = { mark = {}, current_word = "", order = "asc" }
-  -- cached_api_resources.shortNames[name] = resource
+  cached_api_resources.values[name] = value
 
-  -- if resource.singularName then
-  --   cached_api_resources.shortNames[resource.singularName] = name
-  -- end
-  --
-  -- if resource.shortNames then
-  --   for _, shortName in ipairs(resource.shortNames) do
-  --     cached_api_resources.shortNames[shortName] = name
-  --   end
-  -- end
+  if resource.short_names then
+    for _, shortName in ipairs(resource.short_names) do
+      cached_api_resources.shortNames[shortName] = value
+    end
+  end
+  require("kubectl.state").sortby[name] = { mark = {}, current_word = "", order = "asc" }
 end
 
 function M.load_cache(cached_api_resources)

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -18,14 +18,14 @@ function M.open()
   hl.setup()
   vim.schedule(function()
     state.setup()
+    vim.defer_fn(function()
+      cache.LoadFallbackData()
+    end, 2000)
   end)
 
   if config.options.headers.enabled then
     view.Header()
   end
-  vim.schedule(function()
-    cache.LoadFallbackData()
-  end)
 end
 
 function M.close()

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -23,11 +23,9 @@ function M.open()
   if config.options.headers.enabled then
     view.Header()
   end
-  vim.defer_fn(function()
-    vim.schedule(function()
-      cache.LoadFallbackData()
-    end)
-  end, 2000)
+  vim.schedule(function()
+    cache.LoadFallbackData()
+  end)
 end
 
 function M.close()

--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -18,7 +18,9 @@ function M.View(cancellationToken, kind)
   if kind then
     M.resource = kind
   end
+
   local resource = cached_resources.values[string.lower(M.resource)]
+    or cached_resources.shortNames[string.lower(M.resource)]
 
   if not resource then
     require("kubectl.views").resource_or_fallback("pods")
@@ -36,7 +38,7 @@ function M.View(cancellationToken, kind)
 
   local builder = manager.get_or_create(M.definition.resource)
   builder.definition = M.definition
-  builder.buf_nr, builder.win_nr = buffers.buffer(builder.definition.ft, M.resource)
+  builder.buf_nr, builder.win_nr = buffers.buffer(builder.definition.ft, resource.name)
 
   commands.run_async("start_reflector_async", { gvk = M.definition.gvk, namespace = nil }, function()
     vim.schedule(function()


### PR DESCRIPTION
Refactor how we get the cached_api list to include shortnames.

Bonus:
- Fix sorting
- Update telemetry pkg

Fixes: #591 