### PR TITLE
fix: use old sorting for fallback

### DIFF
--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -83,6 +83,7 @@ function M.Draw(cancellationToken)
     builder.decodeJson()
     builder.processedData = builder.data.rows
     builder.definition.headers = builder.data.headers
+    builder.sort()
 
     vim.schedule(function()
       local windows = buffers.get_windows_by_name(builder.definition.resource)


### PR DESCRIPTION
The modern Rust sorting isn't working on fallback resources so falling back (pun intended) on old lua sorting