### PR TITLE
fix: override interactive values and propagate error to user

### DIFF
--- a/kubectl-client/src/store.rs
+++ b/kubectl-client/src/store.rs
@@ -11,7 +11,6 @@ use rayon::prelude::*;
 
 use kube::runtime::reflector::Store;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
 

--- a/lua/kubectl/client/init.lua
+++ b/lua/kubectl/client/init.lua
@@ -9,11 +9,11 @@ local client = {
 function client.set_implementation()
   client.implementation = require("kubectl_client")
   client.implementation.init_logging(vim.fn.stdpath("log"))
-  local ok = client.implementation.init_runtime(state.context["current-context"])
+  local ok, result = client.implementation.init_runtime(state.context["current-context"])
   if ok then
     client.implementation.init_metrics()
   end
-  return ok
+  return ok, result
 end
 
 function client.get_resource(...)

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -14,7 +14,12 @@ local M = {
 function M.open()
   local hl = require("kubectl.actions.highlight")
   local client = require("kubectl.client")
-  client.set_implementation()
+  local ok, result = client.set_implementation()
+
+  if not ok then
+    vim.notify(result, vim.log.levels.ERROR)
+    return
+  end
 
   hl.setup()
   vim.schedule(function()

--- a/lua/kubectl/resources/contexts/init.lua
+++ b/lua/kubectl/resources/contexts/init.lua
@@ -98,7 +98,7 @@ function M.change_context(cmd)
   state.context["current-context"] = cmd
 
   local client = require("kubectl.client")
-  local ok = client.set_implementation()
+  local ok, result = client.set_implementation()
   if ok then
     state.setup()
     local cache = require("kubectl.cache")
@@ -108,7 +108,7 @@ function M.change_context(cmd)
       data = { context = cmd },
     })
   else
-    vim.notify("Failed to initialise client", vim.log.levels.ERROR)
+    vim.notify(result, vim.log.levels.ERROR)
   end
 end
 


### PR DESCRIPTION
Override kubelogin interactive settings so we don't hang, also propagate the error to user