### PR TITLE
feat/save-api-resources-cache

### DIFF
--- a/lua/kubectl/actions/commands.lua
+++ b/lua/kubectl/actions/commands.lua
@@ -311,11 +311,13 @@ function M.execute_terminal(cmd, args, opts)
   vim.cmd("startinsert")
 end
 
+local data_dir = vim.fn.stdpath("data") .. "/kubectl/"
+
 --- Load kubectl.json config file from data dir
 ---@param file_name string The filename to load
 ---@return table|nil The content of the file
-function M.load_config(file_name)
-  local file_path = vim.fn.stdpath("data") .. "/" .. file_name
+function M.read_file(file_name)
+  local file_path = data_dir .. file_name
   local file = io.open(file_path, "r")
   if not file then
     return nil
@@ -331,22 +333,40 @@ function M.load_config(file_name)
   return nil
 end
 
---- Save to config file
+--- Save cache file
 --- @param file_name string The filename to save
 --- @param data table The content to save
-function M.save_config(file_name, data)
-  local config_file = M.load_config("kubectl.json") or {}
-  local merged = vim.tbl_deep_extend("force", config_file, data)
-  local ok, encoded = pcall(vim.json.encode, merged)
-  if ok then
-    local file_path = vim.fn.stdpath("data") .. "/" .. file_name
-    local file = io.open(file_path, "w")
-    if file then
-      file:write(encoded)
-      file:close()
-    end
+--- @return boolean, string|nil True if successful, false and error message if failed
+function M.save_file(file_name, data)
+  local file_path = data_dir .. file_name
+  -- create the directory if it doesn't exist
+  local dir_path = vim.fs.dirname(file_path)
+  if not vim.uv.fs_stat(dir_path) then
+    vim.uv.fs_mkdir(dir_path, 493)
   end
-  return ok
+  local file = io.open(file_path, "w")
+  if not file then
+    return false, "Failed to open file for writing: " .. file_path
+  end
+
+  local ok, encoded = pcall(vim.json.encode, data, { luanil = { object = true, array = true } })
+  if not ok then
+    file:close()
+    return false, "Failed to encode data to JSON: " .. encoded
+  end
+
+  file:write(encoded)
+  file:close()
+  return true
+end
+
+--- Save to config file
+--- @param data table The content to save
+function M.save_config(data)
+  local file_name = "kubectl.json"
+  local config_file = M.read_file(file_name) or {}
+  local merged = vim.tbl_deep_extend("force", config_file, data)
+  M.save_file(file_name, merged)
 end
 
 return M

--- a/lua/kubectl/cache.lua
+++ b/lua/kubectl/cache.lua
@@ -3,17 +3,35 @@ local manager = require("kubectl.resource_manager")
 
 local M = { handles = nil, loading = false, timestamp = nil, cached_api_resources = { values = {}, shortNames = {} } }
 
-local one_day_in_seconds = 24 * 60 * 60
+local ten_min_in_seconds = 10 * 60
 local current_time = os.time()
 
 M.LoadFallbackData = function(force)
-  if force and not M.loading or (M.timestamp == nil or current_time - M.timestamp >= one_day_in_seconds) then
-    M.cached_api_resources.values = {}
-    M.cached_api_resources.shortNames = {}
-
-    M.load_cache(M.cached_api_resources)
-    M.timestamp = os.time()
+  if M.loading then
+    return
   end
+  if force then
+    M.cached_api_resources = { values = {}, shortNames = {} }
+    M.load_cache(M.cached_api_resources)
+    return
+  end
+
+  local ctx = require("kubectl.state").context["current-context"]
+  local cached_data = commands.read_file("api_resources/" .. ctx .. ".json")
+  if not cached_data then
+    M.load_cache(M.cached_api_resources)
+    return
+  end
+
+  local file_write_time =
+    vim.uv.fs_stat(vim.fn.stdpath("data") .. "/kubectl/api_resources/" .. ctx .. ".json").mtime.sec
+
+  if current_time - file_write_time >= ten_min_in_seconds then
+    M.load_cache(M.cached_api_resources)
+    return
+  end
+
+  M.cached_api_resources = cached_data
 end
 
 local function process_apis(resource, cached_api_resources)
@@ -62,6 +80,11 @@ function M.load_cache(cached_api_resources)
     M.loading = false
     vim.schedule(function()
       vim.cmd("doautocmd User KubectlCacheLoaded")
+      local ctx = require("kubectl.state").context["current-context"]
+      local ok, msg = commands.save_file("api_resources/" .. ctx .. ".json", cached_api_resources)
+      if not ok then
+        vim.notify("Failed to save api_resources: " .. msg, vim.log.levels.ERROR)
+      end
     end)
   end)
 end

--- a/lua/kubectl/state.lua
+++ b/lua/kubectl/state.lua
@@ -224,14 +224,14 @@ function M.set_session(view)
   M.session.contexts[session_name] = { view = view, namespace = M.ns }
   M.session.filter_history = M.filter_history
   M.session.alias_history = M.alias_history
-  commands.save_config("kubectl.json", M.session)
+  commands.save_config(M.session)
 end
 
 function M.restore_session()
   local current_context = M.context["current-context"]
   local session_view = "pods"
 
-  local ok, data_or_err = pcall(commands.load_config, "kubectl.json")
+  local ok, data_or_err = pcall(commands.read_file, "kubectl.json")
   if ok and type(data_or_err) == "table" then
     M.session = data_or_err
     local ctx_session = M.session.contexts[current_context]


### PR DESCRIPTION
save the state of the api resources in the filesystem so the loading won't hold back accessing custom resources on startup