### PR TITLE
feat: support NVIM 0.12

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -58,11 +58,22 @@ end
 --- @param header table|nil: The header lines (optional).
 --- @param content table: The content lines.
 local function set_buffer_lines(buf, header, content)
-  if header and #header >= 1 then
-    pcall(vim.api.nvim_buf_set_lines, buf, 0, #header, false, header)
-    pcall(vim.api.nvim_buf_set_lines, buf, #header, -1, false, content)
+  header = header or {}
+  content = content or {}
+
+  if #header == 0 and #content == 0 then
+    return
+  end
+
+  local lines = vim.list_extend(vim.deepcopy(header), content)
+
+  local buftype = vim.api.nvim_get_option_value("buftype", { buf = buf })
+
+  if buftype == "prompt" then
+    local prompt = vim.api.nvim_buf_line_count(buf) - 1
+    vim.api.nvim_buf_set_lines(buf, 0, prompt, false, lines)
   else
-    pcall(vim.api.nvim_buf_set_lines, buf, 0, -1, false, content)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   end
 end
 

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -333,8 +333,8 @@ function M.get_mappings()
       mode = "n",
       desc = "Aliases",
       callback = function()
-        local view = require("kubectl.views")
-        view.Aliases()
+        local view = require("kubectl.views.alias")
+        view.View()
       end,
     },
     ["<Plug>(kubectl.filter_view)"] = {

--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -342,7 +342,7 @@ function M.get_mappings()
       desc = "Filter",
       callback = function()
         local filter_view = require("kubectl.views.filter")
-        filter_view.filter()
+        filter_view.View()
       end,
     },
     ["<Plug>(kubectl.picker_view)"] = {

--- a/lua/kubectl/views/alias/definition.lua
+++ b/lua/kubectl/views/alias/definition.lua
@@ -29,7 +29,6 @@ function M.on_prompt_input(input)
   end
 
   state.alias_history = result
-  print("state: " .. vim.inspect(state.alias_history))
 
   local parsed_input = string.lower(vim.trim(input))
   local view = require("kubectl.views")

--- a/lua/kubectl/views/alias/definition.lua
+++ b/lua/kubectl/views/alias/definition.lua
@@ -29,6 +29,7 @@ function M.on_prompt_input(input)
   end
 
   state.alias_history = result
+  print("state: " .. vim.inspect(state.alias_history))
 
   local parsed_input = string.lower(vim.trim(input))
   local view = require("kubectl.views")

--- a/lua/kubectl/views/alias/init.lua
+++ b/lua/kubectl/views/alias/init.lua
@@ -89,7 +89,6 @@ M.View = function()
       noremap = true,
       callback = function()
         local line = vim.api.nvim_get_current_line()
-				print(line)
 
         -- Don't act on prompt line
         local current_line = vim.api.nvim_win_get_cursor(0)[1]

--- a/lua/kubectl/views/alias/init.lua
+++ b/lua/kubectl/views/alias/init.lua
@@ -2,7 +2,7 @@ local buffers = require("kubectl.actions.buffers")
 local cache = require("kubectl.cache")
 local completion = require("kubectl.utils.completion")
 local config = require("kubectl.config")
-local definition = require("kubectl.views.definition")
+local definition = require("kubectl.views.alias.definition")
 local manager = require("kubectl.resource_manager")
 local state = require("kubectl.state")
 local tables = require("kubectl.utils.tables")
@@ -104,7 +104,7 @@ M.View = function()
 
         if config.options.alias.apply_on_select_from_history then
           vim.schedule(function()
-            -- vim.api.nvim_input("<cr>")
+            vim.api.nvim_input("<cr>")
           end)
         end
       end,

--- a/lua/kubectl/views/alias/init.lua
+++ b/lua/kubectl/views/alias/init.lua
@@ -88,18 +88,20 @@ M.View = function()
     vim.api.nvim_buf_set_keymap(buf, "n", "<Plug>(kubectl.select)", "", {
       noremap = true,
       callback = function()
-        local line = vim.api.nvim_get_current_line()
-
         -- Don't act on prompt line
         local current_line = vim.api.nvim_win_get_cursor(0)[1]
         if current_line >= #header then
           return
         end
 
-        local prompt = "% "
+        local picked = vim.api.nvim_get_current_line()
+        local mark = vim.api.nvim_buf_get_mark(buf, ":")
+        local row = mark[1] - 1
 
-        vim.api.nvim_buf_set_lines(buf, #header + 1, -1, false, { prompt .. line })
-        vim.api.nvim_win_set_cursor(0, { #header + 2, #prompt })
+        local prompt = "% " .. picked
+        vim.api.nvim_buf_set_lines(buf, row, row + 2, false, { prompt })
+
+        vim.api.nvim_win_set_cursor(win, { row + 1, #prompt })
         vim.cmd("startinsert!")
 
         if config.options.alias.apply_on_select_from_history then

--- a/lua/kubectl/views/alias/init.lua
+++ b/lua/kubectl/views/alias/init.lua
@@ -1,0 +1,116 @@
+local buffers = require("kubectl.actions.buffers")
+local cache = require("kubectl.cache")
+local completion = require("kubectl.utils.completion")
+local config = require("kubectl.config")
+local definition = require("kubectl.views.definition")
+local manager = require("kubectl.resource_manager")
+local state = require("kubectl.state")
+local tables = require("kubectl.utils.tables")
+
+local M = {}
+
+M.View = function()
+  local self = manager.get_or_create("aliases")
+  local viewsTable = require("kubectl.utils.viewsTable")
+  self.data = cache.cached_api_resources.values
+  self.splitData().decodeJson()
+  self.data = definition.merge_views(self.data, viewsTable)
+  local buf, win = buffers.aliases_buffer(
+    "k8s_aliases",
+    definition.on_prompt_input,
+    { title = "Aliases - " .. vim.tbl_count(self.data), header = { data = {} }, suggestions = self.data }
+  )
+
+  -- autocmd for KubectlCacheLoaded
+  vim.api.nvim_create_autocmd({ "User" }, {
+    pattern = "KubectlCacheLoaded",
+    callback = function()
+      -- check if win and buf are valid
+      local _, is_valid_win = pcall(vim.api.nvim_win_is_valid, win)
+      local _, is_valid_buf = pcall(vim.api.nvim_buf_is_valid, buf)
+      -- if both valid, update the window title
+      if is_valid_win and is_valid_buf then
+        local new_cached = require("kubectl.cache").cached_api_resources.values
+        self.data = new_cached
+        self.splitData().decodeJson()
+        self.data = definition.merge_views(self.data, viewsTable)
+        vim.api.nvim_win_set_config(win, { title = "k8s_aliases - Aliases - " .. vim.tbl_count(self.data) })
+      end
+    end,
+  })
+
+  completion.with_completion(buf, self.data, function()
+    -- We reassign the cache since it can be slow to load
+    self.data = cache.cached_api_resources.values
+    self.splitData().decodeJson()
+    self.data = definition.merge_views(self.data, viewsTable)
+  end)
+
+  vim.schedule(function()
+    local header, marks = tables.generateHeader({
+      { key = "<Plug>(kubectl.select)", desc = "apply" },
+      { key = "<Plug>(kubectl.refresh)", desc = "refresh" },
+      { key = "<Plug>(kubectl.tab)", desc = "next" },
+      { key = "<Plug>(kubectl.shift_tab)", desc = "previous" },
+      -- TODO: Definition should be moved to mappings.lua
+      { key = "<Plug>(kubectl.quit)", desc = "close" },
+    }, false, false)
+    tables.generateDividerRow(header, marks)
+
+    table.insert(header, "History:")
+    local headers_len = #header
+    for _, value in ipairs(state.alias_history) do
+      table.insert(header, headers_len + 1, value)
+    end
+    table.insert(header, "")
+
+    buffers.set_content(buf, { content = {}, marks = {}, header = { data = header } })
+    vim.api.nvim_buf_set_lines(buf, #header, -1, false, { "Aliases: " })
+
+    buffers.apply_marks(buf, marks, header)
+    buffers.fit_to_content(buf, win, 1)
+
+    vim.api.nvim_buf_set_keymap(buf, "n", "<Plug>(kubectl.refresh)", "", {
+      noremap = true,
+      callback = function()
+        vim.notify("Refreshing aliases...")
+        require("kubectl.cache").LoadFallbackData(true)
+
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "KubectlCacheLoaded",
+          callback = function()
+            vim.notify("Refreshing aliases completed")
+          end,
+        })
+      end,
+    })
+
+    vim.api.nvim_buf_set_keymap(buf, "n", "<Plug>(kubectl.select)", "", {
+      noremap = true,
+      callback = function()
+        local line = vim.api.nvim_get_current_line()
+				print(line)
+
+        -- Don't act on prompt line
+        local current_line = vim.api.nvim_win_get_cursor(0)[1]
+        if current_line >= #header then
+          return
+        end
+
+        local prompt = "% "
+
+        vim.api.nvim_buf_set_lines(buf, #header + 1, -1, false, { prompt .. line })
+        vim.api.nvim_win_set_cursor(0, { #header + 2, #prompt })
+        vim.cmd("startinsert!")
+
+        if config.options.alias.apply_on_select_from_history then
+          vim.schedule(function()
+            -- vim.api.nvim_input("<cr>")
+          end)
+        end
+      end,
+    })
+  end)
+end
+
+return M

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -98,11 +98,13 @@ function M.View()
     end
 
     local picked = vim.api.nvim_get_current_line()
-    local prompt = "% " .. picked
-    local prompt_l = #prompt
+    local mark = vim.api.nvim_buf_get_mark(buf, ":")
+    local row = mark[1] - 1
 
-    vim.api.nvim_buf_set_lines(self.buf_nr, #header + 1, -1, false, { prompt })
-    vim.api.nvim_win_set_cursor(0, { #header + 2, prompt_l })
+    local prompt = "% " .. picked
+    vim.api.nvim_buf_set_lines(buf, row, row + 2, false, { prompt })
+
+    vim.api.nvim_win_set_cursor(win, { row + 1, #prompt })
     vim.cmd("startinsert!")
 
     if config.options.filter.apply_on_select_from_history then

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -1,8 +1,4 @@
 local buffers = require("kubectl.actions.buffers")
-local cache = require("kubectl.cache")
-local completion = require("kubectl.utils.completion")
-local config = require("kubectl.config")
-local definition = require("kubectl.views.definition")
 local find = require("kubectl.utils.find")
 local hl = require("kubectl.actions.highlight")
 local manager = require("kubectl.resource_manager")
@@ -181,109 +177,6 @@ function M.Picker()
   self.displayContent(self.win_nr)
   vim.schedule(function()
     mappings.map_if_plug_not_set("n", "gD", "<Plug>(kubectl.delete)")
-  end)
-end
-
-function M.Aliases()
-  local self = manager.get_or_create("aliases")
-  local viewsTable = require("kubectl.utils.viewsTable")
-  self.data = cache.cached_api_resources.values
-  self.splitData().decodeJson()
-  self.data = definition.merge_views(self.data, viewsTable)
-  local buf, win = buffers.aliases_buffer(
-    "k8s_aliases",
-    definition.on_prompt_input,
-    { title = "Aliases - " .. vim.tbl_count(self.data), header = { data = {} }, suggestions = self.data }
-  )
-
-  -- autocmd for KubectlCacheLoaded
-  vim.api.nvim_create_autocmd("User", {
-    pattern = "KubectlCacheLoaded",
-    callback = function()
-      -- check if win and buf are valid
-      local _, is_valid_win = pcall(vim.api.nvim_win_is_valid, win)
-      local _, is_valid_buf = pcall(vim.api.nvim_buf_is_valid, buf)
-      -- if both valid, update the window title
-      if is_valid_win and is_valid_buf then
-        local new_cached = require("kubectl.cache").cached_api_resources.values
-        self.data = new_cached
-        self.splitData().decodeJson()
-        self.data = definition.merge_views(self.data, viewsTable)
-        vim.api.nvim_win_set_config(win, { title = "k8s_aliases - Aliases - " .. vim.tbl_count(self.data) })
-      end
-    end,
-  })
-
-  completion.with_completion(buf, self.data, function()
-    -- We reassign the cache since it can be slow to load
-    self.data = cache.cached_api_resources.values
-    self.splitData().decodeJson()
-    self.data = definition.merge_views(self.data, viewsTable)
-  end)
-
-  vim.schedule(function()
-    local header, marks = tables.generateHeader({
-      { key = "<Plug>(kubectl.select)", desc = "apply" },
-      { key = "<Plug>(kubectl.refresh)", desc = "refresh" },
-      { key = "<Plug>(kubectl.tab)", desc = "next" },
-      { key = "<Plug>(kubectl.shift_tab)", desc = "previous" },
-      -- TODO: Definition should be moved to mappings.lua
-      { key = "<Plug>(kubectl.quit)", desc = "close" },
-    }, false, false)
-    tables.generateDividerRow(header, marks)
-
-    table.insert(header, "History:")
-    local headers_len = #header
-    for _, value in ipairs(state.alias_history) do
-      table.insert(header, headers_len + 1, value)
-    end
-    table.insert(header, "")
-
-    buffers.set_content(buf, { content = {}, marks = {}, header = { data = header } })
-    vim.api.nvim_buf_set_lines(buf, #header, -1, false, { "Aliases: " })
-
-    buffers.apply_marks(buf, marks, header)
-    buffers.fit_to_content(buf, win, 1)
-
-    vim.api.nvim_buf_set_keymap(buf, "n", "<Plug>(kubectl.refresh)", "", {
-      noremap = true,
-      callback = function()
-        vim.notify("Refreshing aliases...")
-        require("kubectl.cache").LoadFallbackData(true)
-
-        vim.api.nvim_create_autocmd("User", {
-          pattern = "KubectlCacheLoaded",
-          callback = function()
-            vim.notify("Refreshing aliases completed")
-          end,
-        })
-      end,
-    })
-
-    vim.api.nvim_buf_set_keymap(buf, "n", "<Plug>(kubectl.select)", "", {
-      noremap = true,
-      callback = function()
-        local line = vim.api.nvim_get_current_line()
-
-        -- Don't act on prompt line
-        local current_line = vim.api.nvim_win_get_cursor(0)[1]
-        if current_line >= #header then
-          return
-        end
-
-        local prompt = "% "
-
-        vim.api.nvim_buf_set_lines(buf, #header + 1, -1, false, { prompt .. line })
-        vim.api.nvim_win_set_cursor(0, { #header + 2, #prompt })
-        vim.cmd("startinsert!")
-
-        if config.options.alias.apply_on_select_from_history then
-          vim.schedule(function()
-            vim.api.nvim_input("<cr>")
-          end)
-        end
-      end,
-    })
   end)
 end
 


### PR DESCRIPTION
Fixes: #587 

- [x] Floating views broken when selecting item: for some reason, the prompt input was sending the whole buffer instead of just the user input
- [ ] deprecation warnings


@mosheavni Where are the deprecation warnings? I'm not finding any when running `:checkhealth vim.deprecated`, I'll merge this PR and open a new issue if its needed