### PR TITLE
fix: close header properly before trying to open it again

### DIFF
--- a/lua/kubectl/views/header/init.lua
+++ b/lua/kubectl/views/header/init.lua
@@ -47,7 +47,9 @@ function M.View()
         return
       end
       M.Close()
-      M.View()
+      vim.schedule(function()
+        M.View()
+      end)
     end,
   })
 
@@ -121,10 +123,8 @@ function M.Close()
   local builder = manager.get("header")
 
   if builder then
-    vim.schedule(function()
-      pcall(vim.api.nvim_buf_delete, builder.buf_nr, { force = true })
-      manager.remove("header")
-    end)
+    pcall(vim.api.nvim_buf_delete, builder.buf_nr, { force = true })
+    manager.remove("header")
   end
 end
 


### PR DESCRIPTION
Fixes: #630 

We were closing the header after opening it, now we close it properly before opening it.