### PR TITLE
fix: fix incorrect view mapping in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ vim.api.nvim_create_autocmd("FileType", {
     k("n", "", "<Plug>(kubectl.view_jobs)", opts) -- Jobs view
     k("n", "", "<Plug>(kubectl.view_nodes)", opts) -- Nodes view
     k("n", "", "<Plug>(kubectl.view_overview)", opts) -- Overview view
-    k("n", "", "<Plug>(kubectl.view_pv)", opts) -- PersistentVolumes view
-    k("n", "", "<Plug>(kubectl.view_pvc)", opts) -- PersistentVolumeClaims view
+    k("n", "", "<Plug>(kubectl.view_persistentvolumes)", opts) -- PersistentVolumes view
+    k("n", "", "<Plug>(kubectl.view_persistentvolumeclaims)", opts) -- PersistentVolumeClaims view
     k("n", "", "<Plug>(kubectl.view_replicasets)", opts) -- ReplicaSets view,
     k("n", "", "<Plug>(kubectl.view_sa)", opts) -- ServiceAccounts view
     k("n", "", "<Plug>(kubectl.view_statefulsets)", opts) -- StatefulSets view


### PR DESCRIPTION
Hi, thanks for the great work. I noticed that the `kubectl.view_pv` and `kubectl.view_pvc` shortcuts weren't working after I configured them according to the README. It seems the correct commands are `kubectl.view_persistentvolumes` and `kubectl.view_persistentvolumeclaims`. This PR fixes the problem.
