### PR TITLE
fix: remove-filter-on-child-view

### DIFF
--- a/lua/kubectl/mappings.lua
+++ b/lua/kubectl/mappings.lua
@@ -528,6 +528,7 @@ function M.get_mappings()
         if view.definition.child_view then
           if name then
             local child_view = require("kubectl.resources." .. view.definition.child_view.name)
+            state.filter = ""
             state.filter_key = view.definition.child_view.predicate(name, ns)
             child_view.View()
           end


### PR DESCRIPTION
When navigating to a child view, we always want to remove the current filter since it almost never is desired when navigating to child view