### PR TITLE
fix: update key mapping for ServiceAccounts in init.lua and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ vim.api.nvim_create_autocmd("FileType", {
     k("n", "", "<Plug>(kubectl.view_persistentvolumes)", opts) -- PersistentVolumes view
     k("n", "", "<Plug>(kubectl.view_persistentvolumeclaims)", opts) -- PersistentVolumeClaims view
     k("n", "", "<Plug>(kubectl.view_replicasets)", opts) -- ReplicaSets view,
-    k("n", "", "<Plug>(kubectl.view_sa)", opts) -- ServiceAccounts view
+    k("n", "", "<Plug>(kubectl.view_serviceaccounts)", opts) -- ServiceAccounts view
     k("n", "", "<Plug>(kubectl.view_statefulsets)", opts) -- StatefulSets view
     k("n", "", "<Plug>(kubectl.view_storageclasses)", opts) -- StorageClasses view
     k("n", "", "<Plug>(kubectl.view_top_nodes)", opts) -- Top view for nodes

--- a/lua/kubectl/views/init.lua
+++ b/lua/kubectl/views/init.lua
@@ -50,7 +50,7 @@ function M.Hints(headers)
     { key = "<Plug>(kubectl.view_pv)", desc = "PersistentVolumes" },
     { key = "<Plug>(kubectl.view_pvc)", desc = "PersistentVolumeClaims" },
     { key = "<Plug>(kubectl.view_replicasets)", desc = "ReplicaSets" },
-    { key = "<Plug>(kubectl.view_sa)", desc = "ServiceAccounts" },
+    { key = "<Plug>(kubectl.view_serviceaccounts)", desc = "ServiceAccounts" },
     { key = "<Plug>(kubectl.view_secrets)", desc = "Secrets" },
     { key = "<Plug>(kubectl.view_services)", desc = "Services" },
     { key = "<Plug>(kubectl.view_statefulsets)", desc = "StatefulSets" },


### PR DESCRIPTION
Hello, I found `kubectl.view_sa` doesn't exist, this pr fix this problem