### PR TITLE
Fix: Pass namespace to reflector for namespace-scoped RBAC users

### DIFF
--- a/lua/kubectl/resource_factory.lua
+++ b/lua/kubectl/resource_factory.lua
@@ -262,7 +262,9 @@ function M.new(resource)
     builder.buf_nr, builder.win_nr = buffers.buffer(definition.ft, builder.resource)
     state.addToHistory(builder.resource)
 
-    commands.run_async("start_reflector_async", { gvk = definition.gvk, namespace = nil }, function(_, err)
+    -- Use namespace from state to support users with namespace-scoped permissions only
+    local ns = (state.ns and state.ns ~= "All") and state.ns or nil
+    commands.run_async("start_reflector_async", { gvk = definition.gvk, namespace = ns }, function(_, err)
       if err then
         return
       end

--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -41,7 +41,9 @@ function M.View(cancellationToken, kind)
   builder.definition = M.definition
   builder.buf_nr, builder.win_nr = buffers.buffer(builder.definition.ft, resource.name)
 
-  commands.run_async("start_reflector_async", { gvk = M.definition.gvk, namespace = nil }, function()
+  -- Use namespace from state to support users with namespace-scoped permissions only
+  local ns = (state.ns and state.ns ~= "All") and state.ns or nil
+  commands.run_async("start_reflector_async", { gvk = M.definition.gvk, namespace = ns }, function()
     vim.schedule(function()
       M.Draw(cancellationToken)
       vim.cmd("doautocmd User K8sDataLoaded")


### PR DESCRIPTION
### Problem

Users with namespace-scoped Kubernetes permissions (no cluster-admin) see  empty resource lists because `start_reflector_async` always uses `namespace = nil`, causing cluster-scope API requests that return 403 Forbidden.

### Solution

Pass `state.ns` to the reflector, consistent with how `draw()` already handles it:
- If `state.ns == "All"` → pass `nil` (cluster-scope, unchanged behavior)
- If `state.ns == "my-namespace"` → pass the namespace (namespace-scope)

### Changes

- `lua/kubectl/resource_factory.lua`: Use `state.ns` in `view()`
- `lua/kubectl/resources/fallback/init.lua`: Same fix for fallback resources

### Impact

- **Backward compatible**: Users with cluster-admin permissions see no change
- **Fixes**: Namespace-scoped users can now use the plugin by setting  `namespace` in config

### Testing

Tested with a user that has RoleBinding to a single namespace only:
- Before: Empty pod list, 403 errors in `~/.local/state/nvim/kubectl.log`
- After: Pods displayed correctly

Closes #729