### PR TITLE
fix: better toggle to close the plugin

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -368,7 +368,7 @@ function M.header_buffer(win)
 
   if not buf then
     buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_name(buf, "kubect://" .. bufname)
+    vim.api.nvim_buf_set_name(buf, "kubectl://" .. bufname)
     M.set_content(buf, { content = { "Loading..." } })
   end
   local width = 50

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -80,21 +80,18 @@ function M.init(callback)
 end
 
 function M.close()
-  local win_config = vim.api.nvim_win_get_config(0)
   local state = require("kubectl.state")
   local statusline = require("kubectl.views.statusline")
   local header = require("kubectl.views.header")
+  local queue = require("kubectl.event_queue")
+  local manager = require("kubectl.resource_manager")
 
-  if win_config.relative == "" then
-    state.stop_livez()
-  end
+  state.stop_livez()
   statusline.Close()
   header.Close()
   splash.hide()
-  local queue = require("kubectl.event_queue")
   queue.stop()
-
-  vim.api.nvim_buf_delete(0, { force = true })
+  manager.close_all()
 end
 
 --- @param opts { tab: boolean }: Options for toggle function

--- a/lua/kubectl/resource_manager.lua
+++ b/lua/kubectl/resource_manager.lua
@@ -46,4 +46,17 @@ function manager.foreach(prefix, fn)
   end
 end
 
+--- Close all managed windows, delete their buffers, and clear instances
+function manager.close_all()
+  for key, instance in pairs(manager.instances) do
+    if instance.win_nr then
+      pcall(vim.api.nvim_win_close, instance.win_nr, true)
+    end
+    if instance.buf_nr then
+      pcall(vim.api.nvim_buf_delete, instance.buf_nr, { force = true })
+    end
+    manager.instances[key] = nil
+  end
+end
+
 return manager


### PR DESCRIPTION
This makes sure that all buffers/windows created by the manager are cleaned up when close() is called (toggle and such) 