### PR TITLE
fix: lsp issue with blink

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -176,7 +176,9 @@ function M.aliases_buffer(filetype, callback, opts)
     callback(input)
     vim.cmd("stopinsert")
     api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if api.nvim_win_is_valid(win) then
+      api.nvim_win_close(win, true)
+    end
   end)
 
   vim.cmd("startinsert")
@@ -210,7 +212,9 @@ function M.filter_buffer(filetype, callback, opts)
     end
 
     api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if api.nvim_win_is_valid(win) then
+      api.nvim_win_close(win, true)
+    end
     vim.api.nvim_input("<Plug>(kubectl.refresh)")
   end)
 
@@ -298,7 +302,9 @@ function M.floating_dynamic_buffer(filetype, title, callback, opts)
   if opts.prompt then
     vim.fn.prompt_setcallback(buf, function(input)
       api.nvim_set_option_value("modified", false, { buf = buf })
-      vim.cmd.fclose()
+      if api.nvim_win_is_valid(win) then
+        api.nvim_win_close(win, true)
+      end
       vim.api.nvim_input("<Plug>(kubectl.refresh)")
 
       if callback ~= nil then

--- a/lua/kubectl/kubectl.lua
+++ b/lua/kubectl/kubectl.lua
@@ -268,19 +268,27 @@ function M.execute(args)
     return
   end
 
-  -- Run kubectl and show output
+  -- Run kubectl and show output.
+  -- Use vim.schedule to defer window creation until after CmdlineLeave handlers
+  -- finish, preventing E481/invalid-window-id conflicts with blink.cmp.
   local output, err = kubectl_sync(args)
   if err then
-    vim.notify("kubectl error: " .. err, vim.log.levels.ERROR)
+    vim.schedule(function()
+      vim.notify("kubectl error: " .. err, vim.log.levels.ERROR)
+    end)
     return
   end
   if #output == 0 then
-    vim.notify("kubectl: command produced no output", vim.log.levels.INFO)
+    vim.schedule(function()
+      vim.notify("kubectl: command produced no output", vim.log.levels.INFO)
+    end)
     return
   end
 
   local title = "kubectl " .. table.concat(args, " ")
-  open_split(output, title, args)
+  vim.schedule(function()
+    open_split(output, title, args)
+  end)
 end
 
 --- Filter completions by prefix

--- a/lua/kubectl/resources/contexts/init.lua
+++ b/lua/kubectl/resources/contexts/init.lua
@@ -49,7 +49,9 @@ function M.View()
     end
     vim.cmd("stopinsert")
     vim.api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
   end)
 
   vim.cmd("startinsert")

--- a/lua/kubectl/views/alias/init.lua
+++ b/lua/kubectl/views/alias/init.lua
@@ -40,7 +40,9 @@ M.View = function()
     definition.on_prompt_input(input)
     vim.cmd("stopinsert")
     vim.api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
   end)
 
   vim.cmd("startinsert")

--- a/lua/kubectl/views/filter/init.lua
+++ b/lua/kubectl/views/filter/init.lua
@@ -65,7 +65,9 @@ function M.View()
     end
 
     vim.api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
     vim.api.nvim_input("<Plug>(kubectl.refresh)")
   end)
 

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -48,7 +48,9 @@ function M.View()
     end
     vim.cmd("stopinsert")
     vim.api.nvim_set_option_value("modified", false, { buf = buf })
-    vim.cmd.fclose()
+    if vim.api.nvim_win_is_valid(builder.win_nr) then
+      vim.api.nvim_win_close(builder.win_nr, true)
+    end
     vim.schedule(function()
       vim.api.nvim_input("<Plug>(kubectl.refresh)")
     end)


### PR DESCRIPTION
Apparently the fclose is closing blink.cmp window and causing it to keep having issues.
We solve this by explicitly closing our window