### PR TITLE
Helm 4 compatibility

### DIFF
--- a/lua/kubectl/resources/helm/init.lua
+++ b/lua/kubectl/resources/helm/init.lua
@@ -11,7 +11,7 @@ local M = {
     display_name = "Helm",
     ft = "k8s_helm",
     cmd = "helm",
-    url = { "ls", "-a", "-A", "--output", "json" },
+    url = { "ls", "-A", "--output", "json" },
     hints = {
       { key = "<Plug>(kubectl.kill)", desc = "uninstall" },
       { key = "<Plug>(kubectl.values)", desc = "values" },
@@ -43,7 +43,7 @@ end
 
 local function get_args()
   local ns_filter = state.getNamespace()
-  local args = add_namespace({ "ls", "-a", "--output", "json" }, ns_filter)
+  local args = add_namespace({ "ls", "--output", "json" }, ns_filter)
   return args
 end
 

--- a/lua/kubectl/resources/helm/init.lua
+++ b/lua/kubectl/resources/helm/init.lua
@@ -114,7 +114,7 @@ function M.Yaml(name, ns)
     display_name = M.definition.resource .. " | " .. name .. " | " .. ns,
     ft = "k8s_yaml",
     syntax = "yaml",
-    args = { "get", "manifest", name },
+    args = { "get", "manifest", name, "-n", ns },
   }
 
   local builder = manager.get_or_create(def.resource)

--- a/lua/kubectl/resources/helm/init.lua
+++ b/lua/kubectl/resources/helm/init.lua
@@ -90,7 +90,7 @@ function M.Desc(name, ns)
     display_name = M.definition.resource .. " | " .. name .. " | " .. ns,
     ft = "k8s_desc",
     syntax = "yaml",
-    args = { "status", name, "-n", ns, "--show-desc" },
+    args = { "status", name, "-n", ns },
   }
 
   local builder = manager.get_or_create(def.resource)

--- a/lua/kubectl/resources/helm/init.lua
+++ b/lua/kubectl/resources/helm/init.lua
@@ -11,7 +11,8 @@ local M = {
     display_name = "Helm",
     ft = "k8s_helm",
     cmd = "helm",
-    url = { "ls", "-A", "--output", "json" },
+    url = {},
+    version = nil,
     hints = {
       { key = "<Plug>(kubectl.kill)", desc = "uninstall" },
       { key = "<Plug>(kubectl.values)", desc = "values" },
@@ -29,6 +30,16 @@ local M = {
   },
 }
 
+local function get_version()
+  if M.version then
+    return M.version
+  end
+
+  local result = commands.shell_command("helm", { "version", "--template='{{.Version}}'" })
+  M.version = tonumber(result:match("v(%d+)")) or 3
+  return M.version
+end
+
 local function add_namespace(args, ns)
   if ns then
     if ns == "All" then
@@ -41,14 +52,16 @@ local function add_namespace(args, ns)
   return args
 end
 
-local function get_args()
+local function get_args(version)
   local ns_filter = state.getNamespace()
-  local args = add_namespace({ "ls", "--output", "json" }, ns_filter)
+  local base = version < 4 and { "ls", "-a", "--output", "json" } or { "ls", "--output", "json" }
+  local args = add_namespace(base, ns_filter)
   return args
 end
 
 function M.View(cancellationToken)
-  M.definition.url = get_args()
+  M.definition.version = get_version()
+  M.definition.url = get_args(M.definition.version)
   local builder = manager.get_or_create(M.definition.resource)
   builder.definition = M.definition
   builder.buf_nr, builder.win_nr = buffers.buffer(M.definition.ft, builder.resource)
@@ -85,12 +98,16 @@ function M.Draw(cancellationToken)
 end
 
 function M.Desc(name, ns)
+  local status_args = { "status", name, "-n", ns }
+  if get_version() < 4 then
+    table.insert(status_args, "--show-desc")
+  end
   local def = {
     resource = M.definition.resource .. "_desc",
     display_name = M.definition.resource .. " | " .. name .. " | " .. ns,
     ft = "k8s_desc",
     syntax = "yaml",
-    args = { "status", name, "-n", ns },
+    args = status_args,
   }
 
   local builder = manager.get_or_create(def.resource)


### PR DESCRIPTION
## Summary
- **`helm list`**: drop the `-a` flag removed in Helm 4
- **`helm status`**: drop `--show-desc`, removed in [helm/helm#13444](https://github.com/helm/helm/pull/13444); default status output still includes the release description.
- **`helm get manifest`**: pass `-n <namespace>` so the correct release is used when the same name exists in several namespaces.


## Details

This PR adds Helm v4 compatibility and fixes a Lua error triggered when fetching releases:

```
Error executing vim.schedule lua callback: ...y/kubectl.nvim/lua/kubectl/resources/helm/definition.lua:10: bad argument #1 to 'ipairs' (table expected, got string)
stack traceback:
        [C]: in function 'ipairs'
        ...y/kubectl.nvim/lua/kubectl/resources/helm/definition.lua:10: in function 'processFunc'
        .../nvim/lazy/kubectl.nvim/lua/kubectl/resource_factory.lua:76: in function 'process'
        ...im/lazy/kubectl.nvim/lua/kubectl/resources/helm/init.lua:69: in function <...im/lazy/kubectl.nvim/lua/kubectl/resources/helm/init.lua:68>
```

Helm v4 deleted `-a` / `--all` flag from the `list` command:

```
$ helm version
version.BuildInfo{Version:"v4.1.3", GitCommit:"c94d381b03be117e7e57908edbf642104e00eb8f", GitTreeState:"", GoVersion:"go1.26.1-X:nodwarf5", KubeClientVersion:"v1.35"}
$ helm ls -a -A --output json
Error: unknown shorthand flag: 'a' in -a
```

An upstream PR ([helm/helm#31828](https://github.com/helm/helm/pull/31828)) aims to reintroduce it for backward compatibility, but it hasn't been merged yet.

*Note on breaking changes:*

This update changes how kubectl.nvim behaves with Helm v3: superseded, uninstalled, pending-install, and pending-upgrade releases will no longer be displayed in the list.

To maintain the previous behavior across both versions, we could use explicit flags: --pending --deployed --failed --superseded --uninstalled --uninstalling. Let me know if you'd like me to update the PR to maintain full backward compatibility.