### PR TITLE
fix: cluster-scope aware filter

### DIFF
--- a/lua/kubectl/resource_factory.lua
+++ b/lua/kubectl/resource_factory.lua
@@ -262,8 +262,12 @@ function M.new(resource)
     builder.buf_nr, builder.win_nr = buffers.buffer(definition.ft, builder.resource)
     state.addToHistory(builder.resource)
 
-    -- Use namespace from state to support users with namespace-scoped permissions only
-    local ns = (state.ns and state.ns ~= "All") and state.ns or nil
+    local ns = nil
+    if not definition.is_cluster_scoped then
+      if state.ns and state.ns ~= "All" then
+        ns = state.ns
+      end
+    end
     commands.run_async("start_reflector_async", { gvk = definition.gvk, namespace = ns }, function(_, err)
       if err then
         return
@@ -297,7 +301,12 @@ function M.new(resource)
     local definition = builder.definition or {}
     local sort_data = state.sortby[resource]
 
-    local namespace = (state.ns and state.ns ~= "All") and state.ns or nil
+    local namespace = nil
+    if not definition.is_cluster_scoped then
+      if state.ns and state.ns ~= "All" then
+        namespace = state.ns
+      end
+    end
     local sort_by = sort_data and sort_data.current_word or nil
     local sort_order = sort_data and sort_data.order or nil
     local filter = state.getFilter() or nil

--- a/lua/kubectl/resource_factory.lua
+++ b/lua/kubectl/resource_factory.lua
@@ -263,7 +263,7 @@ function M.new(resource)
     state.addToHistory(builder.resource)
 
     local ns = nil
-    if not definition.is_cluster_scoped then
+    if definition.namespaced then
       if state.ns and state.ns ~= "All" then
         ns = state.ns
       end
@@ -302,7 +302,7 @@ function M.new(resource)
     local sort_data = state.sortby[resource]
 
     local namespace = nil
-    if not definition.is_cluster_scoped then
+    if definition.namespaced then
       if state.ns and state.ns ~= "All" then
         namespace = state.ns
       end

--- a/lua/kubectl/resources/base_resource.lua
+++ b/lua/kubectl/resources/base_resource.lua
@@ -17,11 +17,10 @@ function BaseResource.extend(definition, options)
     is_cluster_scoped = not vim.tbl_contains(definition.headers or {}, "NAMESPACE")
   end
 
+  definition.is_cluster_scoped = is_cluster_scoped
+
   local M = {
     definition = definition,
-    _options = {
-      is_cluster_scoped = is_cluster_scoped,
-    },
   }
 
   --- View the resource list
@@ -49,7 +48,7 @@ function BaseResource.extend(definition, options)
   ---@param _ boolean|nil Whether to reload (deprecated, kept for API compatibility)
   function M.Desc(name, ns, _)
     local gvk = { k = M.definition.resource, g = M.definition.gvk.g, v = M.definition.gvk.v }
-    local namespace = M._options.is_cluster_scoped and nil or ns
+    local namespace = M.definition.is_cluster_scoped and nil or ns
     describe_session.view(M.definition.resource, name, namespace, gvk)
   end
 
@@ -76,7 +75,7 @@ function BaseResource.extend(definition, options)
     builder.view_framed(def, {
       args = {
         gvk = M.definition.gvk,
-        namespace = M._options.is_cluster_scoped and nil or ns,
+        namespace = M.definition.is_cluster_scoped and nil or ns,
         name = name,
         output = "yaml",
       },

--- a/lua/kubectl/resources/base_resource.lua
+++ b/lua/kubectl/resources/base_resource.lua
@@ -6,18 +6,11 @@ local BaseResource = {}
 
 --- Create a new resource module based on BaseResource
 ---@param definition table The resource definition table
----@param options? table Optional configuration (is_cluster_scoped)
 ---@return table The resource module with View, Draw, Desc, getCurrentSelection
-function BaseResource.extend(definition, options)
-  options = options or {}
-
-  -- Auto-detect cluster-scoped from headers (no NAMESPACE = cluster-scoped)
-  local is_cluster_scoped = options.is_cluster_scoped
-  if is_cluster_scoped == nil then
-    is_cluster_scoped = not vim.tbl_contains(definition.headers or {}, "NAMESPACE")
+function BaseResource.extend(definition)
+  if definition.namespaced == nil then
+    definition.namespaced = vim.tbl_contains(definition.headers or {}, "NAMESPACE")
   end
-
-  definition.is_cluster_scoped = is_cluster_scoped
 
   local M = {
     definition = definition,
@@ -48,7 +41,10 @@ function BaseResource.extend(definition, options)
   ---@param _ boolean|nil Whether to reload (deprecated, kept for API compatibility)
   function M.Desc(name, ns, _)
     local gvk = { k = M.definition.resource, g = M.definition.gvk.g, v = M.definition.gvk.v }
-    local namespace = M.definition.is_cluster_scoped and nil or ns
+    local namespace = nil
+    if M.definition.namespaced then
+      namespace = ns
+    end
     describe_session.view(M.definition.resource, name, namespace, gvk)
   end
 
@@ -75,7 +71,7 @@ function BaseResource.extend(definition, options)
     builder.view_framed(def, {
       args = {
         gvk = M.definition.gvk,
-        namespace = M.definition.is_cluster_scoped and nil or ns,
+        namespace = M.definition.namespaced and ns or nil,
         name = name,
         output = "yaml",
       },

--- a/lua/kubectl/resources/events/init.lua
+++ b/lua/kubectl/resources/events/init.lua
@@ -22,9 +22,6 @@ local M = BaseResource.extend({
     "MESSAGE",
     "NAME",
   },
-}, {
-  name_column_index = 8,
-  namespace_column_index = 1,
 })
 
 function M.ShowMessage(ns, object, event)

--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -36,14 +36,14 @@ function M.View(cancellationToken, kind)
   M.definition.ft = "k8s_" .. resource.name
   M.definition.plural = resource.plural
   M.definition.crd_name = resource.crd_name
-  M.definition.is_cluster_scoped = not resource.namespaced
+  M.definition.namespaced = resource.namespaced
 
   local builder = manager.get_or_create(M.definition.resource)
   builder.definition = M.definition
   builder.buf_nr, builder.win_nr = buffers.buffer(builder.definition.ft, resource.name)
 
   local ns = nil
-  if not M.definition.is_cluster_scoped then
+  if M.definition.namespaced then
     if state.ns and state.ns ~= "All" then
       ns = state.ns
     end
@@ -64,7 +64,7 @@ function M.Draw(cancellationToken)
   end
 
   local ns = nil
-  if not builder.definition.is_cluster_scoped then
+  if builder.definition.namespaced then
     if state.ns and state.ns ~= "All" then
       ns = state.ns
     end

--- a/lua/kubectl/resources/fallback/init.lua
+++ b/lua/kubectl/resources/fallback/init.lua
@@ -36,13 +36,18 @@ function M.View(cancellationToken, kind)
   M.definition.ft = "k8s_" .. resource.name
   M.definition.plural = resource.plural
   M.definition.crd_name = resource.crd_name
+  M.definition.is_cluster_scoped = not resource.namespaced
 
   local builder = manager.get_or_create(M.definition.resource)
   builder.definition = M.definition
   builder.buf_nr, builder.win_nr = buffers.buffer(builder.definition.ft, resource.name)
 
-  -- Use namespace from state to support users with namespace-scoped permissions only
-  local ns = (state.ns and state.ns ~= "All") and state.ns or nil
+  local ns = nil
+  if not M.definition.is_cluster_scoped then
+    if state.ns and state.ns ~= "All" then
+      ns = state.ns
+    end
+  end
   commands.run_async("start_reflector_async", { gvk = M.definition.gvk, namespace = ns }, function()
     vim.schedule(function()
       M.Draw(cancellationToken)
@@ -59,8 +64,10 @@ function M.Draw(cancellationToken)
   end
 
   local ns = nil
-  if state.ns and state.ns ~= "All" then
-    ns = state.ns
+  if not builder.definition.is_cluster_scoped then
+    if state.ns and state.ns ~= "All" then
+      ns = state.ns
+    end
   end
 
   local filter = state.getFilter()

--- a/lua/kubectl/utils/terminal.lua
+++ b/lua/kubectl/utils/terminal.lua
@@ -83,8 +83,12 @@ function M.spawn_terminal(title, key, fn, is_fullscreen, ...)
   end
 
   vim.schedule(function()
-    vim.api.nvim_set_current_win(win)
-    M.attach_session(sess, buf, win)
+    if win and buf then
+      vim.api.nvim_set_current_win(win)
+      M.attach_session(sess, buf, win)
+    else
+      vim.notify("Cannot attach to terminal without a valid buffer or window", vim.log.levels.WARN)
+    end
   end)
 end
 


### PR DESCRIPTION
Currently, when filtering on namespace but viewing clnuster-scoped resources we would filter everything.
This change ignore filtering when on cluster-scoped resources.