### PR TITLE
fix(go): read KUBECONFIG via libc to honor host-side setenv

### DIFF
--- a/go/kubedescribe.go
+++ b/go/kubedescribe.go
@@ -7,7 +7,9 @@ import "C"
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
+	"unsafe"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -20,6 +22,24 @@ import (
 	"k8s.io/kubectl/pkg/describe"
 )
 
+// libcGetenv reads an environment variable through libc's getenv(3) instead of
+// Go's runtime.envs cache. The Go runtime captures a snapshot of environ at
+// process startup; subsequent setenv(3) calls performed by the host process
+// (here: Neovim/libuv via vim.fn.setenv) are invisible to os.Getenv but visible
+// to libc. Without this bypass, KUBECONFIG changes made by the user after
+// Neovim has started (e.g. switching kube context via a plugin) are silently
+// ignored, and client-go falls back to ~/.kube/config — leading to requests
+// hitting the wrong cluster URL.
+func libcGetenv(key string) string {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+	cVal := C.getenv(cKey)
+	if cVal == nil {
+		return ""
+	}
+	return C.GoString(cVal)
+}
+
 var (
 	cfgCache    sync.Map
 	mapperCache sync.Map
@@ -31,18 +51,32 @@ func gvrKey(ctx string, gvr schema.GroupVersionResource) string {
 }
 
 func getRestConfig(ctx string) (*rest.Config, error) {
-	if v, ok := cfgCache.Load(ctx); ok {
+	// Read KUBECONFIG via libc so that runtime updates from the host process
+	// (e.g. setenv() from the embedding plugin) are honored.
+	kubeconfigPath := libcGetenv("KUBECONFIG")
+
+	// Cache key includes the path: a KUBECONFIG switch must invalidate the
+	// cached *rest.Config for the same context name.
+	cacheKey := ctx + "|" + kubeconfigPath
+
+	if v, ok := cfgCache.Load(cacheKey); ok {
 		return v.(*rest.Config), nil
 	}
 
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfigPath != "" {
+		// Force client-go to use the path read from libc, not the value cached
+		// by the Go runtime (which may be empty and would fall back to
+		// ~/.kube/config — the source of the bug above).
+		loadingRules.Precedence = filepath.SplitList(kubeconfigPath)
+	}
 	overrides := &clientcmd.ConfigOverrides{CurrentContext: ctx}
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 	cfg, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
-	if v, dup := cfgCache.LoadOrStore(ctx, cfg); dup {
+	if v, dup := cfgCache.LoadOrStore(cacheKey, cfg); dup {
 		return v.(*rest.Config), nil
 	}
 	return cfg, nil


### PR DESCRIPTION
When kubectl.nvim is loaded as a cgo shared library inside an embedding process (e.g. Neovim), the Go runtime captures a snapshot of `environ` at startup. Subsequent setenv(3) calls performed by the host (e.g. vim.fn.setenv from Lua) update libc's environ but are invisible to os.Getenv on the Go side.

This causes KUBECONFIG changes made after the host has started -- typically when a plugin switches kube context after spawning a tunnel -- to be silently ignored. client-go falls back to ~/.kube/config and returns a *rest.Config pointing at the cluster's public URL instead of the user-provided kubeconfig (e.g. a forwarded local endpoint), leading to DNS/connection timeouts on private clusters.

Bypass the Go runtime cache by reading KUBECONFIG through C.getenv() and feeding it explicitly to clientcmd.LoadingRules.Precedence. The cache key in cfgCache also includes the path so that a KUBECONFIG switch invalidates the previously cached *rest.Config for the same context name.

Ref : https://github.com/Ramilito/kubectl.nvim/issues/765