### PR TITLE
feat: notify-on-binary-status

### DIFF
--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -244,7 +244,24 @@ function M.download_if_available(callback)
     root_dir = root_dir,
     output_dir = "/target/release",
     binary_name = "kubectl_client", -- excluding `lib` prefix
-  }, callback)
+  }, function(err)
+    if err ~= nil then
+      vim.notify(
+        "[kubectl.nvim] Binary not downloaded: "
+          .. tostring(err)
+          .. ". Ensure your plugin manager has kubectl.nvim checked out at a tagged release commit.",
+        vim.log.levels.WARN,
+        { title = "kubectl.nvim" }
+      )
+    else
+      vim.notify(
+        "[kubectl.nvim] Binary download complete. Please restart Neovim.",
+        vim.log.levels.INFO,
+        { title = "kubectl.nvim" }
+      )
+    end
+    callback(err)
+  end)
 end
 
 return M

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -245,7 +245,7 @@ function M.download_if_available(callback)
     output_dir = "/target/release",
     binary_name = "kubectl_client", -- excluding `lib` prefix
   }, function(err)
-    if err ~= nil then
+    if err and err ~= nil then
       vim.notify(
         "[kubectl.nvim] Binary not downloaded: "
           .. tostring(err)

--- a/lua/kubectl/init.lua
+++ b/lua/kubectl/init.lua
@@ -253,12 +253,6 @@ function M.download_if_available(callback)
         vim.log.levels.WARN,
         { title = "kubectl.nvim" }
       )
-    else
-      vim.notify(
-        "[kubectl.nvim] Binary download complete. Please restart Neovim.",
-        vim.log.levels.INFO,
-        { title = "kubectl.nvim" }
-      )
     end
     callback(err)
   end)


### PR DESCRIPTION
Add some notifications for when the binary download has finished or has failed.

for example:

```
11:46:27 │ [kubectl.nvim] Binary not downloaded: ...pack/core/opt/blink.download/lua/blink/download/init.lua:37: No rust library found, but can't download due to not being on a git tag.. Ensure your plugin manager has kubectl.nvim checked out at a tagged release commit.
```