### PR TITLE
fix: ui-flicker-on-edit

### DIFF
--- a/lua/kubectl/actions/buffers.lua
+++ b/lua/kubectl/actions/buffers.lua
@@ -393,10 +393,10 @@ function M.header_buffer(win)
   local win_opts = {
     relative = "editor",
     anchor = "NW",
-    width = col,
+    width = width,
     height = height,
     row = row,
-    col = total_cols,
+    col = col,
     style = "minimal",
     border = "rounded",
     focusable = false,

--- a/lua/kubectl/views/header/init.lua
+++ b/lua/kubectl/views/header/init.lua
@@ -95,7 +95,10 @@ function M.View()
     pattern = "K8sDataLoaded",
     callback = function()
       vim.schedule(function()
-        M.Draw()
+        local ft = vim.bo.filetype
+        if ft and ft:match("^k8s_") then
+          M.Draw()
+        end
       end)
     end,
   })
@@ -146,7 +149,7 @@ function M.View()
 end
 
 function M.Draw()
-  if not config.options.headers.enabled and M.is_drawing then
+  if not config.options.headers.enabled or M.is_drawing then
     return
   end
   if is_overlapping() then


### PR DESCRIPTION
## Summary

Three bug fixes in the header floating window, two of which cause continuous UI flickering when editing a resource in a new tab (`ge`).

### 1. Fix continuous screen redraws when in non-k8s buffer (flickering)

`K8sDataLoaded` is emitted every time any resource view auto-refreshes (every `auto_refresh.interval` ms). The `header` listener had no guard against this, so `Draw()` - and by extension
`nvim_win_set_config` - was called at full refresh rate regardless of whether the current buffer was a k8s buffer.
Since `nvim_win_set_config` always schedules a global screen flush (including the tabline), this caused non-stop visible flickering in any non-k8s window, such as the YAML edit tab opened by `ge`.
Added the same filetype guard already present in the `BufEnter` handler: only call `Draw()` when `vim.bo.filetype` matches `^k8s_`.

### 2. Fix dead re-entrancy guard in `Draw()`

The guard `if not config.options.headers.enabled and M.is_drawing` used `and` instead of `or`.
With `headers.enabled = true` (the default), `not true AND anything` is always `false`, making `M.is_drawing`
completely inert and allowing concurrent draws.
Changed to `or` so that either condition correctly short-circuits the draw.

### 3. Fix swapped `width`/`col` in `header_buffer` win_opts

`win_opts` had `width = col` and `col = total_cols`. This placed the header window with its left edge at `total_cols` (the right edge of the screen) and gave it a width of `total_cols - 50` (~170 chars) -
placing it entirely off-screen to the right.
The values are swapped: `width = width` (50) and `col = col` (`total_cols - 50`), which positions the window correctly at the bottom-right corner.