### PR TITLE
fix: detect changes when deleting fields on edit

### DIFF
--- a/kubectl-client/src/cmd/edit.rs
+++ b/kubectl-client/src/cmd/edit.rs
@@ -50,10 +50,21 @@ pub async fn edit_async(_lua: Lua, json: String) -> LuaResult<String> {
         live.managed_fields_mut().clear();
         obj.managed_fields_mut().clear();
         obj.metadata.managed_fields = None;
+        obj.metadata.resource_version = live.metadata.resource_version.clone();
         normalize_finalizers_for_ssa(&mut obj, &live);
 
+        let live_val = serde_json::to_value(&live)
+            .map_err(|e| mlua::Error::RuntimeError(format!("failed to serialize live object: {e}")))?;
+        let obj_val = serde_json::to_value(&obj)
+            .map_err(|e| mlua::Error::RuntimeError(format!("failed to serialize obj: {e}")))?;
+
+        let merge = merge_patch_diff(&live_val, &obj_val);
+        if merge.as_object().is_some_and(|m| m.is_empty()) {
+            return Ok(format!("no changes detected for {}/{}", ar.plural, name));
+        }
+
         let field_manager = "kubectl-edit-lua";
-        let patch = Patch::Merge(&obj);
+        let patch = Patch::Merge(&merge);
         let pp = PatchParams::apply(field_manager);
 
         let mut simulated = match api.patch(&name, &pp.clone().dry_run(), &patch).await {
@@ -67,8 +78,6 @@ pub async fn edit_async(_lua: Lua, json: String) -> LuaResult<String> {
         };
         simulated.managed_fields_mut().clear();
 
-        let live_val = serde_json::to_value(&live)
-            .map_err(|e| mlua::Error::RuntimeError(format!("failed to serialize live object: {e}")))?;
         let simulated_val = serde_json::to_value(&simulated)
             .map_err(|e| mlua::Error::RuntimeError(format!("failed to serialize simulated object: {e}")))?;
         let changed = live_val != simulated_val;
@@ -95,4 +104,36 @@ fn normalize_finalizers_for_ssa(obj: &mut DynamicObject, live: &DynamicObject) {
     if user_removed_field && live_has_finalizers {
         obj.metadata.finalizers = Some(Vec::new());
     }
+}
+
+/// Compute an RFC 7386 JSON Merge Patch from `from` → `to`.
+/// Keys present in `from` but absent in `to` become explicit `null` (deletion).
+fn merge_patch_diff(from: &serde_json::Value, to: &serde_json::Value) -> serde_json::Value {
+    use serde_json::{Map, Value};
+
+    let (Value::Object(from_map), Value::Object(to_map)) = (from, to) else {
+        return to.clone();
+    };
+
+    let mut out = Map::new();
+    for key in from_map.keys() {
+        if !to_map.contains_key(key) {
+            out.insert(key.clone(), Value::Null); // deletion
+        }
+    }
+    for (key, to_val) in to_map {
+        match from_map.get(key) {
+            Some(from_val) if from_val == to_val => {}
+            Some(from_val) => {
+                let diff = merge_patch_diff(from_val, to_val);
+                if !matches!(&diff, Value::Object(m) if m.is_empty()) {
+                    out.insert(key.clone(), diff);
+                }
+            }
+            None => {
+                out.insert(key.clone(), to_val.clone());
+            }
+        }
+    }
+    Value::Object(out)
 }


### PR DESCRIPTION
When editing a resource and only deleting lines, it notified "no changes detected" and never applied the changes.

The edit sent the whole object as a JSON merge patch, which can't represent deletions (an omitted key just means "leave unchanged"), so the dry-run result always matched the live object.

Now it computes a proper merge-patch diff between the live and edited object, so removed keys become explicit nulls. Deletions are detected and applied, while value changes keep working as before.