### PR TITLE
fix: ignore stale async callbacks in namespace and context pickers

### DIFF
--- a/lua/kubectl/resources/contexts/init.lua
+++ b/lua/kubectl/resources/contexts/init.lua
@@ -61,6 +61,9 @@ function M.View()
     builder.decodeJson()
 
     vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(buf) then
+        return
+      end
       builder.process(M.processRow, true).prettyPrint().displayContent(win)
       builder.fitToContent(1)
 

--- a/lua/kubectl/views/namespace/init.lua
+++ b/lua/kubectl/views/namespace/init.lua
@@ -66,6 +66,9 @@ function M.View()
       builder.data = data
       builder.decodeJson()
       vim.schedule(function()
+        if not vim.api.nvim_buf_is_valid(buf) then
+          return
+        end
         builder.process(definition.processRow, true).prettyPrint()
         builder.displayContent(builder.win_nr)
         builder.fitToContent()


### PR DESCRIPTION
## Summary

- Guard the scheduled async callback in the namespace and context pickers with `nvim_buf_is_valid(buf)` before updating UI
- Prevents `Invalid buffer id` errors when the picker is closed (namespace/context selected) before `get_all_async` / `get_config_async` completes

## Context

Since #696 (framed view) and #757 (`nvim_win_close` with wipe), closing the picker deletes the buffer while the async fetch may still be in flight. `displayContent` already bails on an invalid window; `nvim_buf_set_keymap` did not.

Matches the existing guard in `resource_factory.lua` draw path.

## Test plan

- [ ] Open namespace picker (`<C-n>`), select a namespace before the list finishes loading — no error, namespace changes and view refreshes
- [ ] Open namespace picker, wait for list, select a namespace — works as before
- [ ] Same two checks for context picker (`:Kubectx`)

Made with [Cursor](https://cursor.com)